### PR TITLE
v0.1.0+: AI 整理书签 + UX 改进 + i18n 修复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ web-ext.config.ts
 *.njsproj
 *.sln
 *.sw?
+
+# npm lockfile (project uses pnpm)
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "sync bookmarks"
   ],
   "private": true,
-  "version": "0.0.6",
+  "version": "0.1.0",
   "type": "module",
   "author": "dudor",
   "license": "",
@@ -18,6 +18,8 @@
     "zip": "wxt zip",
     "zip:firefox": "wxt zip -b firefox",
     "compile": "tsc --noEmit",
+    "validate:locales": "python3 scripts/validate_locales.py",
+    "prebuild": "npm run validate:locales",
     "postinstall": "wxt prepare"
   },
   "dependencies": {
@@ -35,9 +37,14 @@
     "@types/chrome": "^0.0.280",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^5.0.4",
     "@wxt-dev/auto-icons": "^1.0.2",
     "@wxt-dev/module-react": "^1.1.1",
     "typescript": "^5.6.3",
+    "vite": "^7.3.5",
     "wxt": "^0.19.13"
+  },
+  "overrides": {
+    "@vitejs/plugin-react": "$@vitejs/plugin-react@5.0.4"
   }
 }

--- a/scripts/validate_locales.py
+++ b/scripts/validate_locales.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Chrome MV3 i18n messages.json validator.
+
+Chrome refuses to load a locale file if any key uses a different JSON shape than
+the rest of the file (Chrome treats "all-object" and "all-flat-string" as the two
+valid shapes, but mixing them fails with:
+    "Not a valid tree for key <name>"
+https://developer.chrome.com/docs/extensions/reference/api/i18n#locales
+
+Usage:
+    python3 validate_locales.py <locales_dir>
+    # default: /root/bookmarkhub-workspace/bookmarkhub/src/public/_locales
+
+Exit codes:
+    0 = all locale files pass
+    1 = at least one file has mixed/invalid shape
+"""
+import json
+import sys
+from pathlib import Path
+
+LOCALES_DIR_DEFAULT = Path("/root/bookmarkhub-workspace/bookmarkhub/src/public/_locales")
+
+
+def validate_locale(path: Path) -> tuple[bool, list[str]]:
+    """Return (ok, errors). ok=True means the file is loadable by Chrome."""
+    errors: list[str] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        return False, [f"JSON parse error: {e}"]
+
+    if not isinstance(data, dict):
+        return False, ["root must be a JSON object"]
+
+    flat_keys: list[str] = []
+    obj_keys: list[str] = []
+    for k, v in data.items():
+        if isinstance(v, str):
+            flat_keys.append(k)
+        elif isinstance(v, dict):
+            obj_keys.append(k)
+            # Validate inner object
+            if "message" not in v:
+                errors.append(f"key {k!r} is missing required 'message' field")
+            elif not isinstance(v["message"], str):
+                errors.append(f"key {k!r}.message is not a string")
+            if "description" in v and not isinstance(v["description"], str):
+                errors.append(f"key {k!r}.description is not a string")
+            if "placeholders" in v:
+                ph = v["placeholders"]
+                if not isinstance(ph, dict):
+                    errors.append(f"key {k!r}.placeholders is not an object")
+                else:
+                    for phk, phv in ph.items():
+                        if not isinstance(phv, dict) or "content" not in phv:
+                            errors.append(
+                                f"key {k!r}.placeholders.{phk} missing required 'content'"
+                            )
+        else:
+            errors.append(f"key {k!r} has invalid type {type(v).__name__}")
+
+    if flat_keys and obj_keys:
+        errors.append(
+            f"MIXED FORMAT: {len(flat_keys)} flat-string keys + {len(obj_keys)} object keys. "
+            f"Chrome refuses mixed format. Offending flat keys: {flat_keys[:5]}"
+        )
+
+    return not errors, errors
+
+
+def main():
+    locales_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else LOCALES_DIR_DEFAULT
+    if not locales_dir.is_dir():
+        print(f"ERROR: {locales_dir} is not a directory", file=sys.stderr)
+        return 2
+
+    any_fail = False
+    print(f"Validating {locales_dir}")
+    print("-" * 70)
+    for p in sorted(locales_dir.glob("*/messages.json")):
+        ok, errors = validate_locale(p)
+        flag = "✅" if ok else "❌"
+        print(f"{flag} {p.parent.name}: {len(errors)} errors")
+        for e in errors:
+            print(f"    - {e}")
+        if not ok:
+            any_fail = True
+    print("-" * 70)
+    if any_fail:
+        print("RESULT: ❌ FAIL — Chrome will refuse to load at least one locale file")
+        return 1
+    print("RESULT: ✅ ALL PASS — every locale file is loadable by Chrome")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -3,9 +3,22 @@ import { Setting } from '../utils/setting'
 import iconLogo from '../assets/icon.png'
 import { OperType, BookmarkInfo, SyncDataInfo, RootBookmarksType, BrowserType } from '../utils/models'
 import { Bookmarks } from 'wxt/browser'
+
+// =============== 定时自动同步常量 ===============
+const ALARM_NAME = 'bookmarkhub-auto-sync';           // alarm 名（固定）
+const MIN_INTERVAL_MIN = 15;                          // 最小间隔 15 分钟
+const DEFAULT_INTERVAL_MIN = 60;                      // 默认间隔 60 分钟
+
+// =============== AI 整理书签常量 ===============
+const AI_ORGANIZE_STATE_KEY = 'aiOrganizeState';      // storage key
+const AI_ORGANIZE_POLL_ALARM = 'bookmarkhub-ai-organize-poll'; // 轮询 alarm (1 分钟)
+const AI_ORGANIZE_TIMEOUT_MS = 30 * 60 * 1000;        // 30 分钟超时
+
 export default defineBackground(() => {
 
   browser.runtime.onInstalled.addListener(c => {
+    // 安装/更新后，初始化 alarm
+    refreshAlarm().catch(err => console.error('init alarm error:', err));
   });
 
   let curOperType = OperType.NONE;
@@ -13,19 +26,29 @@ export default defineBackground(() => {
   browser.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     if (msg.name === 'upload') {
       curOperType = OperType.SYNC
-      uploadBookmarks().then(() => {
+      // ===== 触发源 02：手动上传 =====
+      uploadBookmarks().then(async (ok) => {
         curOperType = OperType.NONE
         browser.action.setBadgeText({ text: "" });
-        refreshLocalCount();
+        await refreshLocalCount();
+        if (ok) {
+          // 手动上传成功后，更新统一同步时间
+          await setLastSyncAt('manual');
+        }
         sendResponse(true);
       });
     }
     if (msg.name === 'download') {
       curOperType = OperType.SYNC
-      downloadBookmarks().then(() => {
+      // ===== 触发源 02：手动下载 =====
+      downloadBookmarks().then(async (ok) => {
         curOperType = OperType.NONE
         browser.action.setBadgeText({ text: "" });
-        refreshLocalCount();
+        await refreshLocalCount();
+        if (ok) {
+          // 手动下载成功后，更新统一同步时间
+          await setLastSyncAt('manual');
+        }
         sendResponse(true);
       });
 
@@ -44,6 +67,54 @@ export default defineBackground(() => {
       browser.runtime.openOptionsPage().then(() => {
         sendResponse(true);
       });
+    }
+    // ===== 新增：手动触发刷新 alarm 的消息（用于设置页保存后立即生效） =====
+    if (msg.name === 'refreshAutoSync') {
+      refreshAlarm().then(() => sendResponse(true)).catch(err => {
+        console.error(err);
+        sendResponse(false);
+      });
+      return true;
+    }
+    // ===== 新增：手动触发立即自动同步 =====
+    if (msg.name === 'runAutoSyncNow') {
+      runAutoSync().then(() => sendResponse(true)).catch(err => {
+        console.error(err);
+        sendResponse(false);
+      });
+      return true;
+    }
+    // ===== 新增：启动 AI 整理书签任务 =====
+    if (msg.name === 'aiOrganizeStart') {
+      aiOrganizeStart()
+        .then(res => sendResponse(res))
+        .catch(err => {
+          console.error('[aiOrganize] start error:', err);
+          sendResponse({ ok: false, error: String(err?.message || err) });
+        });
+      return true;
+    }
+    // ===== 新增：获取 AI 整理状态 =====
+    if (msg.name === 'aiOrganizeGetState') {
+      aiOrganizeGetState()
+        .then(res => sendResponse(res))
+        .catch(err => {
+          console.error('[aiOrganize] getState error:', err);
+          sendResponse({ ok: false, error: String(err?.message || err) });
+        });
+      return true;
+    }
+    // ===== 新增：清除 AI 整理状态 =====
+    if (msg.name === 'aiOrganizeClearState') {
+      aiOrganizeClearState()
+        .then(() => sendResponse({ ok: true }))
+        .catch(err => sendResponse({ ok: false, error: String(err?.message || err) }));
+      return true;
+    }
+    // ===== 新增：直接打开 popup 窗口（无任务也可手动触发，目前保留作为内部工具） =====
+    if (msg.name === 'aiOrganizeOpenPopup') {
+      openPopupWindow().then(res => sendResponse(res)).catch(err => sendResponse({ ok: false, error: String(err?.message || err) }));
+      return true;
     }
     return true;
   });
@@ -78,7 +149,360 @@ export default defineBackground(() => {
     }
   })
 
-  async function uploadBookmarks() {
+  // =============== 监听 chrome.alarms 事件 ===============
+  // MV3 Service Worker 中不能用 setInterval，必须用 chrome.alarms
+  // 周期最小 1 分钟；为避免太频繁校验，最小同步间隔 15 分钟（前端 UI 限制）
+  browser.alarms.onAlarm.addListener((alarm) => {
+    if (alarm.name === ALARM_NAME) {
+      console.log(`[BookmarkHub] alarm fired at ${new Date().toISOString()}`);
+      runAutoSync().catch(err => console.error('auto sync error:', err));
+    }
+  });
+
+  // =============== 监听浏览器启动事件（可选：用于立即触发一次） ===============
+  browser.runtime.onStartup.addListener(() => {
+    console.log('[BookmarkHub] browser startup, refreshing alarm');
+    refreshAlarm().then(async () => {
+      const setting = await Setting.build();
+      if (setting.enableAutoSync && setting.autoSyncOnStartup) {
+        console.log('[BookmarkHub] startup auto sync triggered');
+        runAutoSync().catch(err => console.error('startup sync error:', err));
+      }
+    }).catch(err => console.error(err));
+  });
+
+  /**
+   * 刷新/重建 alarm：
+   *   - 如果未启用自动同步，清除 alarm
+   *   - 如果已启用且配置变更，重建 alarm
+   *   - interval < 15 分钟时强制为 15 分钟（chrome.alarms 周期至少 1 分钟，
+   *     但太短会触发 API 限流和浏览器节流）
+   */
+  async function refreshAlarm() {
+    const setting = await Setting.build();
+    const existing = await browser.alarms.get(ALARM_NAME);
+    if (!setting.enableAutoSync) {
+      if (existing) {
+        await browser.alarms.clear(ALARM_NAME);
+        console.log('[BookmarkHub] auto sync disabled, alarm cleared');
+      }
+      return;
+    }
+    let interval = Math.max(MIN_INTERVAL_MIN, Math.floor(setting.autoSyncInterval || DEFAULT_INTERVAL_MIN));
+    // Chrome alarms API periodInMinutes 最小值为 1，这里我们直接用 periodInMinutes 即可
+    const opts: any = { periodInMinutes: interval };
+    if (existing) {
+      await browser.alarms.clear(ALARM_NAME);
+    }
+    await browser.alarms.create(ALARM_NAME, opts);
+    console.log(`[BookmarkHub] alarm created with interval ${interval} min, direction=${setting.autoSyncDirection}`);
+  }
+
+  /**
+   * 执行一次自动同步
+   *   - 单一操作过程中通过 curOperType 锁住，避免与手动操作/书签事件冲突
+   *   - 同步方向: upload / download / bidirectional
+   *   - 同步完成后更新时间戳；失败不更新
+   */
+  async function runAutoSync() {
+    const setting = await Setting.build();
+    if (!setting.enableAutoSync) {
+      console.log('[BookmarkHub] auto sync skipped (disabled)');
+      return;
+    }
+    // 校验基础配置
+    if (!setting.githubToken || !setting.gistID || !setting.gistFileName) {
+      console.warn('[BookmarkHub] auto sync skipped: missing token/gist/filename');
+      if (setting.enableNotify) {
+        await browser.notifications.create({
+          type: "basic",
+          iconUrl: iconLogo,
+          title: browser.i18n.getMessage('autoSyncTitle'),
+          message: browser.i18n.getMessage('autoSyncMissingConfig')
+        });
+      }
+      return;
+    }
+
+    // 加锁：避免与手动同步/书签事件冲突
+    if (curOperType !== OperType.NONE) {
+      console.log('[BookmarkHub] auto sync skipped: another operation in progress');
+      return;
+    }
+    curOperType = OperType.SYNC;
+
+    try {
+      const direction = setting.autoSyncDirection;
+      console.log(`[BookmarkHub] auto sync start, direction=${direction}`);
+      let anyOk = false;
+      if (direction === 'upload') {
+        anyOk = await uploadBookmarks({ silent: true });
+      } else if (direction === 'download') {
+        anyOk = await downloadBookmarks({ silent: true });
+      } else {
+        // bidirectional: 先下载再上传（保证两端一致）
+        const dlOk = await downloadBookmarks({ silent: true });
+        const ulOk = await uploadBookmarks({ silent: true });
+        anyOk = dlOk || ulOk;
+      }
+      // 至少一个方向成功才更新同步时间
+      if (anyOk) {
+        // 触发源 01: 定时自动同步成功
+        await setLastSyncAt('auto');
+        // 自动同步成功后，主动刷新本地计数（清掉 "!" 红标）
+        await refreshLocalCount();
+        browser.action.setBadgeText({ text: "" });
+        console.log('[BookmarkHub] auto sync done at', new Date().toISOString());
+      } else {
+        console.warn('[BookmarkHub] auto sync all directions failed, lastSyncAt not updated');
+      }
+    } catch (e) {
+      console.error('[BookmarkHub] auto sync failed:', e);
+    } finally {
+      curOperType = OperType.NONE;
+    }
+  }
+
+  // =============== AI 整理书签：核心逻辑 ===============
+
+  /**
+   * 启动 AI 整理任务：
+   *  1. 校验配置（token / gist_id / file_name / backend_url）
+   *  2. 调用后端 /api/organize/start 拿到 task_id
+   *  3. 写入 storage 的 aiOrganizeState
+   *  4. 创建 chrome.alarms 1 分钟轮询后端状态
+   *
+   * 返回: { ok: true, task_id } 或 { ok: false, error: '...' }
+   */
+  async function aiOrganizeStart(): Promise<{ ok: boolean; task_id?: string; state?: any; error?: string }> {
+    const setting = await Setting.build();
+    if (!setting.githubToken || !setting.gistID || !setting.gistFileName) {
+      return { ok: false, error: browser.i18n.getMessage('aiOrganizeMissingConfig') || 'Please configure Token / Gist ID / File Name first' };
+    }
+    if (!setting.aiOrganizeBackendUrl) {
+      return { ok: false, error: 'AI Organize Backend URL is empty' };
+    }
+
+    // 检查是否已有任务在跑
+    const existing = await browser.storage.local.get(AI_ORGANIZE_STATE_KEY);
+    const prevState = existing?.[AI_ORGANIZE_STATE_KEY];
+    if (prevState && (prevState.status === 'pending' || prevState.status === 'running')) {
+      return { ok: false, error: 'A previous task is still running', state: prevState };
+    }
+
+    const startedAt = Date.now();
+    // 写初始状态
+    const initState = {
+      task_id: null,
+      status: 'pending',  // pending / running / success / failed
+      progress: { current: 0, total: 0, current_step: browser.i18n.getMessage('aiOrganizeRunningTitle') || '🤖 AI Organizing…', message: '' },
+      result: null,
+      error: null,
+      log: [],
+      started_at: startedAt,
+      finished_at: null,
+      dismissed: false,
+      backend_url: setting.aiOrganizeBackendUrl,
+    };
+    await browser.storage.local.set({ [AI_ORGANIZE_STATE_KEY]: initState });
+
+    try {
+      // 调后端
+      const url = setting.aiOrganizeBackendUrl.replace(/\/+$/, '') + '/api/organize/start';
+      const resp = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          gist_token: setting.githubToken,
+          gist_id: setting.gistID,
+          gist_file_name: setting.gistFileName,
+          max_concurrency: 5,
+          classify_concurrency: 3,
+        }),
+      });
+      if (!resp.ok) {
+        const txt = await resp.text();
+        throw new Error(`Backend HTTP ${resp.status}: ${txt.slice(0, 200)}`);
+      }
+      const data = await resp.json();
+      if (!data.task_id) {
+        throw new Error('Backend did not return task_id');
+      }
+
+      // 更新状态
+      const newState = {
+        ...initState,
+        task_id: data.task_id,
+        status: 'running',
+        progress: { current: 0, total: 0, current_step: browser.i18n.getMessage('aiOrganizeRunningTitle') || '🤖 AI Organizing…', message: 'Task started' },
+      };
+      await browser.storage.local.set({ [AI_ORGANIZE_STATE_KEY]: newState });
+
+      // 创建轮询 alarm（1 分钟一次）—— service worker 不持久，popup 也会自己轮询
+      try {
+        await browser.alarms.create(AI_ORGANIZE_POLL_ALARM, { periodInMinutes: 1 });
+      } catch (e) {
+        console.warn('[aiOrganize] failed to create poll alarm:', e);
+      }
+
+      return { ok: true, task_id: data.task_id, state: newState };
+    } catch (e: any) {
+      const errMsg = e?.message || String(e);
+      const failState = {
+        ...initState,
+        status: 'failed',
+        error: errMsg,
+        finished_at: Date.now(),
+      };
+      await browser.storage.local.set({ [AI_ORGANIZE_STATE_KEY]: failState });
+      return { ok: false, error: errMsg, state: failState };
+    }
+  }
+
+  /**
+   * 获取 AI 整理当前状态：
+   *  - 如果后端有 task_id 且未结束，主动 poll 一次后端拿最新进度
+   *  - 更新 storage 中的状态
+   *  - 返回给 popup
+   */
+  async function aiOrganizeGetState(): Promise<{ ok: boolean; state?: any; error?: string }> {
+    const data = await browser.storage.local.get(AI_ORGANIZE_STATE_KEY);
+    const state = data?.[AI_ORGANIZE_STATE_KEY];
+    if (!state) {
+      return { ok: true, state: null };
+    }
+    // 如果已经终态，直接返回
+    if (state.status === 'success' || state.status === 'failed') {
+      return { ok: true, state };
+    }
+    // 如果还没拿到 task_id 或正在 pending，直接返回
+    if (!state.task_id) {
+      return { ok: true, state };
+    }
+    // 主动 poll 一次后端
+    try {
+      const url = (state.backend_url || '').replace(/\/+$/, '') + `/api/organize/${state.task_id}/status`;
+      const resp = await fetch(url, { method: 'GET' });
+      if (!resp.ok) {
+        // 后端暂时连不上，返回原状态
+        return { ok: true, state };
+      }
+      const remote = await resp.json();
+      const newState = {
+        ...state,
+        status: remote.status || state.status,
+        progress: remote.progress || state.progress,
+        log: remote.log || state.log,
+        result: remote.result || state.result,
+        error: remote.error || null,
+        finished_at: (remote.status === 'success' || remote.status === 'failed') ? Date.now() : state.finished_at,
+      };
+      await browser.storage.local.set({ [AI_ORGANIZE_STATE_KEY]: newState });
+      // 终态时清理轮询 alarm
+      if (newState.status === 'success' || newState.status === 'failed') {
+        try { await browser.alarms.clear(AI_ORGANIZE_POLL_ALARM); } catch (e) { /* ignore */ }
+      }
+      return { ok: true, state: newState };
+    } catch (e: any) {
+      // 网络错误：返回原状态
+      return { ok: true, state };
+    }
+  }
+
+  /**
+   * 打开 popup 窗口（已开则聚焦，不再开新窗口）
+   *  - 整理过程中不调用此函数，避免打扰用户
+   *  - 任务完成后由 alarm 监听器调用，自动弹出汇总详情
+   */
+  async function openPopupWindow(): Promise<{ ok: boolean; focused?: boolean; error?: string }> {
+    const popupUrl = browser.runtime.getURL('popup.html');
+    return new Promise((resolve) => {
+      try {
+        chrome.windows.getAll({ windowTypes: ['popup'] }, (wins) => {
+          const target = (wins || []).find(w => (w as any).tabs?.some((t: any) => t.url?.startsWith(popupUrl)));
+          if (target && target.id != null) {
+            chrome.windows.update(target.id, { focused: true, drawAttention: true }, () => {
+              const lastErr = chrome.runtime.lastError;
+              if (lastErr) {
+                resolve({ ok: false, error: lastErr.message });
+              } else {
+                resolve({ ok: true, focused: true });
+              }
+            });
+          } else {
+            chrome.windows.create({
+              url: popupUrl,
+              type: 'popup',
+              width: 420,
+              height: 560,
+              focused: true,
+            }, () => {
+              const lastErr = chrome.runtime.lastError;
+              if (lastErr) {
+                resolve({ ok: false, error: lastErr.message });
+              } else {
+                resolve({ ok: true, focused: false });
+              }
+            });
+          }
+        });
+      } catch (e: any) {
+        resolve({ ok: false, error: String(e?.message || e) });
+      }
+    });
+  }
+
+  /**
+   * 清除 AI 整理状态（用户点关闭模态框后调用，避免重复弹）
+   */
+  async function aiOrganizeClearState(): Promise<void> {
+    try { await browser.alarms.clear(AI_ORGANIZE_POLL_ALARM); } catch (e) { /* ignore */ }
+    await browser.storage.local.remove(AI_ORGANIZE_STATE_KEY);
+  }
+
+  /**
+   * 检查是否需要自动弹出 popup 窗口（任务完成且 popup 未弹过）
+   *  - 仅在状态从非 success 转入 success 时触发，避免重复弹
+   *  - 设置 popup_auto_opened=true 后再次轮询就不会再触发
+   */
+  async function maybeAutoOpenPopupOnComplete(prevStatus: string | undefined, currStatus: string): Promise<void> {
+    if (currStatus !== 'success') return;
+    if (prevStatus === 'success') return; // 不是首次进入 success，不重复弹
+    const data = await browser.storage.local.get(AI_ORGANIZE_STATE_KEY);
+    const st = data?.[AI_ORGANIZE_STATE_KEY];
+    if (!st || st.status !== 'success') return;
+    if (st.dismissed) return;          // 用户已经关闭过，不重复弹
+    if (st.popup_auto_opened) return;  // 已经弹过，不重复弹
+    // 标记 + 打开
+    await browser.storage.local.set({
+      [AI_ORGANIZE_STATE_KEY]: { ...st, popup_auto_opened: true }
+    });
+    const r = await openPopupWindow();
+    console.log('[aiOrganize] auto-open popup on complete:', r);
+  }
+
+  // 监听 AI 整理轮询 alarm
+  browser.alarms.onAlarm.addListener(async (alarm) => {
+    if (alarm.name === AI_ORGANIZE_POLL_ALARM) {
+      try {
+        // 记录轮询前状态
+        const before = await browser.storage.local.get(AI_ORGANIZE_STATE_KEY);
+        const prevStatus = before?.[AI_ORGANIZE_STATE_KEY]?.status;
+        // 正常轮询后端
+        await aiOrganizeGetState();
+        // 轮询后再读一次状态，检查是否刚转入 success → 自动弹 popup
+        const after = await browser.storage.local.get(AI_ORGANIZE_STATE_KEY);
+        const currStatus = after?.[AI_ORGANIZE_STATE_KEY]?.status;
+        if (currStatus) {
+          await maybeAutoOpenPopupOnComplete(prevStatus, currStatus);
+        }
+      } catch (err) {
+        console.error('[aiOrganize] poll error:', err);
+      }
+    }
+  });
+
+  async function uploadBookmarks(opts: { silent?: boolean } = {}): Promise<boolean> {
     try {
       let setting = await Setting.build()
       if (setting.githubToken == '') {
@@ -106,7 +530,7 @@ export default defineBackground(() => {
       });
       const count = getBookmarkCount(syncdata.bookmarks);
       await browser.storage.local.set({ remoteCount: count });
-      if (setting.enableNotify) {
+      if (setting.enableNotify && !opts.silent) {
         await browser.notifications.create({
           type: "basic",
           iconUrl: iconLogo,
@@ -114,6 +538,7 @@ export default defineBackground(() => {
           message: browser.i18n.getMessage('success')
         });
       }
+      return true;
 
     }
     catch (error: any) {
@@ -124,16 +549,17 @@ export default defineBackground(() => {
         title: browser.i18n.getMessage('uploadBookmarks'),
         message: `${browser.i18n.getMessage('error')}：${error.message}`
       });
+      return false;
     }
   }
-  async function downloadBookmarks() {
+  async function downloadBookmarks(opts: { silent?: boolean } = {}): Promise<boolean> {
     try {
       let gist = await BookmarkService.get();
       let setting = await Setting.build()
       if (gist) {
         let syncdata: SyncDataInfo = JSON.parse(gist);
         if (syncdata.bookmarks == undefined || syncdata.bookmarks.length == 0) {
-          if (setting.enableNotify) {
+          if (setting.enableNotify && !opts.silent) {
             await browser.notifications.create({
               type: "basic",
               iconUrl: iconLogo,
@@ -141,13 +567,13 @@ export default defineBackground(() => {
               message: `${browser.i18n.getMessage('error')}：Gist File ${setting.gistFileName} is NULL`
             });
           }
-          return;
+          return false;
         }
-        await clearBookmarkTree();
+        await clearBookmarkTree({ silent: true });
         await createBookmarkTree(syncdata.bookmarks);
         const count = getBookmarkCount(syncdata.bookmarks);
         await browser.storage.local.set({ remoteCount: count });
-        if (setting.enableNotify) {
+        if (setting.enableNotify && !opts.silent) {
           await browser.notifications.create({
             type: "basic",
             iconUrl: iconLogo,
@@ -155,6 +581,7 @@ export default defineBackground(() => {
             message: browser.i18n.getMessage('success')
           });
         }
+        return true;
       }
       else {
         await browser.notifications.create({
@@ -163,6 +590,7 @@ export default defineBackground(() => {
           title: browser.i18n.getMessage('downloadBookmarks'),
           message: `${browser.i18n.getMessage('error')}：Gist File ${setting.gistFileName} Not Found`
         });
+        return false;
       }
     }
     catch (error: any) {
@@ -173,6 +601,7 @@ export default defineBackground(() => {
         title: browser.i18n.getMessage('downloadBookmarks'),
         message: `${browser.i18n.getMessage('error')}：${error.message}`
       });
+      return false;
     }
   }
 
@@ -187,7 +616,7 @@ export default defineBackground(() => {
     return bookmarkTree;
   }
 
-  async function clearBookmarkTree() {
+  async function clearBookmarkTree(opts: { silent?: boolean } = {}) {
     try {
       let setting = await Setting.build()
       if (setting.githubToken == '') {
@@ -213,7 +642,7 @@ export default defineBackground(() => {
           }
         }
       }
-      if (curOperType === OperType.REMOVE && setting.enableNotify) {
+      if (curOperType === OperType.REMOVE && setting.enableNotify && !opts.silent) {
         await browser.notifications.create({
           type: "basic",
           iconUrl: iconLogo,
@@ -319,6 +748,22 @@ export default defineBackground(() => {
     let bookmarkList = await getBookmarks();
     const count = getBookmarkCount(bookmarkList);
     await browser.storage.local.set({ localCount: count });
+  }
+
+  /**
+   * 写入统一同步时间字段。
+   * 字段：lastSyncAt (number) + lastSyncSource ('auto' | 'manual')
+   *   - 触发源 01: runAutoSync() 成功后调用 setLastSyncAt('auto')
+   *   - 触发源 02: 手动 upload/download 成功后调用 setLastSyncAt('manual')
+   * 同时兼容旧字段 lastAutoSyncTime，避免老用户 options 页读不到时间。
+   */
+  async function setLastSyncAt(source: 'auto' | 'manual') {
+    const now = Date.now();
+    await browser.storage.local.set({
+      lastSyncAt: now,
+      lastSyncSource: source,
+      lastAutoSyncTime: now,  // 兼容老字段
+    });
   }
 
 

--- a/src/entrypoints/options/index.html
+++ b/src/entrypoints/options/index.html
@@ -5,9 +5,8 @@
     <meta name="color-scheme" content="dark light" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BookmarkHub,sync bookmarks across different browsers</title>
-    <meta name="manifest.open_in_tab" content="false" />
-    <!-- <meta name="manifest.chrome_style" content="false" /> -->
-    <meta name="manifest.browser_style" content="false" />
+    <!-- 改为 true：点击扩展选项/工具栏"设置"时，用新标签页打开，不再嵌入侧边栏小弹框 -->
+    <meta name="manifest.open_in_tab" content="true" />
  
   </head>
   <body>

--- a/src/entrypoints/options/options.css
+++ b/src/entrypoints/options/options.css
@@ -1,4 +1,28 @@
 #root {
-    margin: 10px;
-    width: 500px;
+    /* 居中布局：左右 auto + 略微加宽，避免字段拥挤 */
+    margin: 10px auto;
+    width: 640px;
+    max-width: calc(100vw - 20px);
+}
+#formOptions {
+    margin-bottom: 20px;
+}
+/* 字段下的辅助说明文字：稍小、灰色 */
+.form-help {
+    color: #888;
+    font-size: 11px;
+    margin-top: 4px;
+    line-height: 1.4;
+}
+/* 字段下的快捷操作链接行（创建 Gist / 查看 Gist） */
+.form-actions {
+    margin-top: 4px;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+    font-size: 12px;
+}
+.form-actions .sep {
+    color: #ccc;
 }

--- a/src/entrypoints/options/options.tsx
+++ b/src/entrypoints/options/options.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import ReactDOM from 'react-dom/client';
-import { Container, Form, Button, Col, Row, InputGroup, Alert } from 'react-bootstrap';
+import { Container, Form, Button, Col, Row, InputGroup, Alert, Modal } from 'react-bootstrap';
 import { useForm } from "react-hook-form";
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './options.css'
@@ -37,6 +37,7 @@ const Popup: React.FC = () => {
     // ====== AI 整理状态（与 popup 共享）======
     const [aiState, setAiState] = useState<any>(null);
     const [aiStartPending, setAiStartPending] = useState(false);
+    const [showAiResultModal, setShowAiResultModal] = useState(false);
     const pollTimerRef = React.useRef<any>(null);
 
     useEffect(() => {
@@ -45,6 +46,10 @@ const Popup: React.FC = () => {
                 const r: any = await browser.runtime.sendMessage({ name: 'aiOrganizeGetState' });
                 if (r?.ok && r.state) {
                     setAiState(r.state);
+                    // 终态 + 未关闭过 → 显示汇总模态框
+                    if ((r.state.status === 'success' || r.state.status === 'failed') && !r.state.dismissed) {
+                        setShowAiResultModal(true);
+                    }
                 } else {
                     setAiState(null);
                 }
@@ -98,6 +103,109 @@ const Popup: React.FC = () => {
     };
 
     const aiIsRunning = aiState && (aiState.status === 'running' || aiState.status === 'pending');
+
+    /**
+     * 关闭 AI 整理结果模态框 + 清除 storage
+     */
+    const handleCloseAiResultModal = async () => {
+        setShowAiResultModal(false);
+        try {
+            await browser.runtime.sendMessage({ name: 'aiOrganizeClearState' });
+        } catch (e) { /* ignore */ }
+        setAiState(null);
+    };
+
+    /**
+     * 渲染 AI 整理结果汇总模态框
+     */
+    const renderAiResultModal = () => {
+        if (!aiState || (aiState.status !== 'success' && aiState.status !== 'failed')) return null;
+        const isSuccess = aiState.status === 'success';
+        return (
+            <Modal
+                show={showAiResultModal}
+                onHide={handleCloseAiResultModal}
+                backdrop="static"
+                size="sm"
+                centered
+            >
+                <Modal.Header closeButton>
+                    <Modal.Title style={{ fontSize: '16px' }}>
+                        {isSuccess
+                            ? (browser.i18n.getMessage('aiOrganizeModalTitle') || '🎉 Organize Complete')
+                            : (browser.i18n.getMessage('aiOrganizeFailed') || '❌ Organize Failed')}
+                    </Modal.Title>
+                </Modal.Header>
+                <Modal.Body style={{ padding: '12px 16px' }}>
+                    {isSuccess && aiState.result ? (
+                        <>
+                            <div style={{ fontSize: 13, marginBottom: 10, color: '#374151' }}>
+                                {(browser.i18n.getMessage('aiOrganizeModalSummary') || 'Organized {count} bookmarks into {cats} categories')
+                                    .replace('{count}', String(aiState.result.total_bookmarks || 0))
+                                    .replace('{cats}', String(aiState.result.category_count || 0))}
+                            </div>
+                            {aiState.result.categories && aiState.result.categories.length > 0 && (
+                                <div style={{
+                                    border: '1px solid #e5e7eb',
+                                    borderRadius: 6,
+                                    overflow: 'hidden',
+                                    marginBottom: 10,
+                                }}>
+                                    {aiState.result.categories.map((c: any, i: number) => (
+                                        <div
+                                            key={i}
+                                            style={{
+                                                display: 'flex',
+                                                justifyContent: 'space-between',
+                                                alignItems: 'center',
+                                                padding: '6px 12px',
+                                                fontSize: 13,
+                                                borderBottom: i < aiState.result.categories.length - 1 ? '1px solid #f3f4f6' : 'none',
+                                                background: i % 2 === 0 ? '#fff' : '#fafafa',
+                                            }}
+                                        >
+                                            <span style={{ color: '#1f2937' }}>
+                                                <span style={{
+                                                    display: 'inline-block',
+                                                    width: 6, height: 6,
+                                                    borderRadius: '50%',
+                                                    background: '#6366f1',
+                                                    marginRight: 8,
+                                                }} />
+                                                {c.category}
+                                            </span>
+                                            <span style={{
+                                                background: '#eef2ff',
+                                                color: '#4338ca',
+                                                fontSize: 11,
+                                                fontWeight: 600,
+                                                padding: '2px 8px',
+                                                borderRadius: 10,
+                                            }}>
+                                                {c.count}
+                                            </span>
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                            <div style={{ fontSize: 11, color: '#6b7280', lineHeight: 1.4 }}>
+                                {browser.i18n.getMessage('aiOrganizeModalHint') || 'Click "Download Bookmarks" in popup to see the result.'}
+                            </div>
+                        </>
+                    ) : (
+                        <div style={{ fontSize: 13, color: '#dc2626' }}>
+                            {aiState?.error || 'Unknown error'}
+                        </div>
+                    )}
+                </Modal.Body>
+                <Modal.Footer style={{ padding: '8px 16px' }}>
+                    <Button variant="primary" size="sm" onClick={handleCloseAiResultModal}>
+                        {browser.i18n.getMessage('aiOrganizeModalClose') || 'Close'}
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+        );
+    };
 
     useEffect(() => {
         optionsStorage.syncForm('#formOptions');
@@ -388,6 +496,7 @@ const Popup: React.FC = () => {
                     </Col>
                 </Form.Group>
             </Form>
+            {renderAiResultModal()}
         </Container >
     )
 }

--- a/src/entrypoints/options/options.tsx
+++ b/src/entrypoints/options/options.tsx
@@ -1,15 +1,162 @@
 import React, { useState, useEffect } from 'react'
 import ReactDOM from 'react-dom/client';
-import { Container, Form, Button, Col, Row, InputGroup } from 'react-bootstrap';
+import { Container, Form, Button, Col, Row, InputGroup, Alert } from 'react-bootstrap';
 import { useForm } from "react-hook-form";
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './options.css'
 import optionsStorage from '../../utils/optionsStorage'
+
+// 同步周期下拉选项：标签通过 i18n 读取（key 形如 autoSyncInterval_1h）
+// 浏览器全局 i18n 在模块顶层即可获取，组件渲染时 label 已就绪
+const INTERVAL_OPTIONS: { value: number; label: string; i18nKey: string }[] = [
+    { value: 15,   i18nKey: 'autoSyncInterval_15m' },
+    { value: 30,   i18nKey: 'autoSyncInterval_30m' },
+    { value: 60,   i18nKey: 'autoSyncInterval_1h'  },
+    { value: 120,  i18nKey: 'autoSyncInterval_2h'  },
+    { value: 360,  i18nKey: 'autoSyncInterval_6h'  },
+    { value: 720,  i18nKey: 'autoSyncInterval_12h' },
+    { value: 1440, i18nKey: 'autoSyncInterval_24h' },
+    { value: 2880, i18nKey: 'autoSyncInterval_48h' },
+    { value: 4320, i18nKey: 'autoSyncInterval_72h' },
+].map(o => ({ value: o.value, i18nKey: o.i18nKey, label: browser.i18n.getMessage(o.i18nKey as any) }));
+
 const Popup: React.FC = () => {
-    const { register, setValue } = useForm();
+    const { register, setValue, watch, getValues } = useForm();
+    const enableAutoSync = watch('enableAutoSync');
+    // 监听 Gist ID 输入，实时驱动"View Gist"按钮可用性 + URL
+    const gistID = (watch('gistID') || '').trim();
+    const gistFileName = (watch('gistFileName') || 'BookmarkHub').trim();
+    const [gistUrl, setGistUrl] = useState('');
+    useEffect(() => {
+        // 简化 URL：gist.github.com/<id> 公开/私密 Gist 都可用（登录态下私密也可访问）
+        setGistUrl(gistID ? `https://gist.github.com/${encodeURIComponent(gistID)}` : '');
+    }, [gistID]);
+    const [lastSyncText, setLastSyncText] = useState('');
+    const [saveHint, setSaveHint] = useState('');
+
+    // ====== AI 整理状态（与 popup 共享）======
+    const [aiState, setAiState] = useState<any>(null);
+    const [aiStartPending, setAiStartPending] = useState(false);
+    const pollTimerRef = React.useRef<any>(null);
+
+    useEffect(() => {
+        const tick = async () => {
+            try {
+                const r: any = await browser.runtime.sendMessage({ name: 'aiOrganizeGetState' });
+                if (r?.ok && r.state) {
+                    setAiState(r.state);
+                } else {
+                    setAiState(null);
+                }
+            } catch (e) { /* ignore */ }
+        };
+        tick();
+        pollTimerRef.current = setInterval(tick, 1500);
+        return () => {
+            if (pollTimerRef.current) clearInterval(pollTimerRef.current);
+        };
+    }, []);
+
+    /**
+     * 渲染 AI 整理进度条（仅在 running/pending 时显示）
+     */
+    const renderAiProgress = () => {
+        if (!aiState || (aiState.status !== 'running' && aiState.status !== 'pending')) return null;
+        const total = aiState.progress?.total || 0;
+        const current = aiState.progress?.current || 0;
+        const step = aiState.progress?.current_step || '';
+        const message = aiState.progress?.message || '';
+        const pct = total > 0 ? Math.min(100, Math.round((current / total) * 100)) : 0;
+        const labelTpl = browser.i18n.getMessage('aiOrganizeProgressLabel') || '已完成 {current} / {total}（{step}）';
+        const label = labelTpl
+            .replace('{current}', String(current))
+            .replace('{total}', String(total || '?'))
+            .replace('{step}', step);
+
+        return (
+            <div style={{
+                marginTop: 10, padding: 10,
+                background: 'linear-gradient(135deg, #eef2ff 0%, #e0e7ff 100%)',
+                borderRadius: 6, border: '1px solid #c7d2fe',
+            }}>
+                <div style={{ fontSize: 12, color: '#4338ca', fontWeight: 600, marginBottom: 6 }}>
+                    {browser.i18n.getMessage('aiOrganizeRunningTitle') || '🤖 AI 整理中…'}
+                </div>
+                <div style={{ height: 6, background: '#fff', borderRadius: 3, overflow: 'hidden', marginBottom: 4 }}>
+                    <div style={{
+                        width: `${pct}%`, height: '100%',
+                        background: 'linear-gradient(90deg, #6366f1 0%, #8b5cf6 100%)',
+                        transition: 'width 0.3s ease',
+                    }} />
+                </div>
+                <div style={{ fontSize: 11, color: '#6366f1' }}>{label}</div>
+                {message && message !== step && (
+                    <div style={{ fontSize: 10, color: '#888', marginTop: 2 }}>{message}</div>
+                )}
+            </div>
+        );
+    };
+
+    const aiIsRunning = aiState && (aiState.status === 'running' || aiState.status === 'pending');
+
     useEffect(() => {
         optionsStorage.syncForm('#formOptions');
     }, [])
+
+    useEffect(() => {
+        // 读取上次同步时间，显示在 UI（兼容旧字段 lastAutoSyncTime）
+        const loadLastSync = async () => {
+            const data = await browser.storage.local.get(['lastSyncAt', 'lastAutoSyncTime']);
+            const ts = data?.lastSyncAt || data?.lastAutoSyncTime;
+            if (ts) {
+                const d = new Date(ts);
+                setLastSyncText(d.toLocaleString());
+            } else {
+                setLastSyncText(browser.i18n.getMessage('autoSyncNever') || 'Never');
+            }
+        };
+        loadLastSync();
+    }, [])
+
+    const onSave = async () => {
+        // webext-options-sync 会自动把表单数据写入 storage；这里手动触发一次
+        // 并通知 background 重建 alarm
+        await optionsStorage.setAll(getValues());
+        try {
+            await browser.runtime.sendMessage({ name: 'refreshAutoSync' });
+            setSaveHint(browser.i18n.getMessage('autoSyncSaved') || 'Saved, auto-sync settings applied');
+        } catch (e) {
+            setSaveHint(browser.i18n.getMessage('autoSyncSaveError') || 'Saved, but failed to notify background');
+        }
+        setTimeout(() => setSaveHint(''), 3000);
+    }
+
+    const onRunNow = async () => {
+        const runHint = document.getElementById('runNowHint');
+        const setHint = (text: string, variant: 'info' | 'success' | 'danger' = 'info') => {
+            if (!runHint) return;
+            runHint.textContent = text;
+            runHint.className = `alert alert-${variant}`;
+            runHint.style.display = 'block';
+        };
+        try {
+            setHint(browser.i18n.getMessage('autoSyncRunning') || '⏳ Syncing...', 'info');
+            await browser.runtime.sendMessage({ name: 'runAutoSyncNow' });
+            // 刷新时间（兼容新字段 lastSyncAt 和旧字段 lastAutoSyncTime）
+            const data = await browser.storage.local.get(['lastSyncAt', 'lastAutoSyncTime']);
+            const ts = data?.lastSyncAt || data?.lastAutoSyncTime;
+            if (ts) {
+                const t = new Date(ts).toLocaleString();
+                setLastSyncText(t);
+                setHint((browser.i18n.getMessage('autoSyncRunSuccess') || '✅ Synced at ') + t, 'success');
+            } else {
+                setHint(browser.i18n.getMessage('autoSyncRunDone') || '✅ Sync completed', 'success');
+            }
+        } catch (e: any) {
+            console.error(e);
+            setHint((browser.i18n.getMessage('autoSyncRunError') || '❌ Sync failed: ') + (e?.message || String(e)), 'danger');
+        }
+    }
 
     return (
         <Container>
@@ -20,16 +167,39 @@ const Popup: React.FC = () => {
                         <InputGroup size="sm">
                             <Form.Control name="githubToken" ref={register} type="text" placeholder="github token" size="sm" />
                             <InputGroup.Append>
-                                <Button variant="outline-secondary" as="a" target="_blank" href="https://github.com/settings/tokens/new" size="sm">Get Token</Button>
+                                <Button variant="outline-secondary" as="a" target="_blank" rel="noopener noreferrer" href="https://github.com/settings/tokens/new" size="sm">{browser.i18n.getMessage('getToken') || 'Get Token'}</Button>
                             </InputGroup.Append>
                         </InputGroup>
+                        <div className="form-help">{browser.i18n.getMessage('githubTokenHelp') || '需要一个有 gist 权限的 Personal Access Token (classic)'}</div>
                     </Col>
                 </Form.Group>
 
                 <Form.Group as={Row}>
                     <Form.Label column="sm" sm={3} lg={2} xs={3}>{browser.i18n.getMessage('gistID')}</Form.Label>
                     <Col sm={9} lg={10} xs={9}>
-                        <Form.Control name="gistID" ref={register} type="text" placeholder="gist ID" size="sm" />
+                        {/* Gist ID 输入框独占整行，不再被按钮挤压，避免输入体验受影响 */}
+                        <Form.Control name="gistID" ref={register} type="text" placeholder="e.g. a1b2c3d4e5f6..." size="sm" />
+                        <div className="form-actions">
+                            <a href="https://gist.github.com/" target="_blank" rel="noopener noreferrer">
+                                {browser.i18n.getMessage('createNewGist') || '📝 创建 Gist'} ↗
+                            </a>
+                            <span className="sep">|</span>
+                            <Button
+                                variant="link"
+                                size="sm"
+                                style={{ padding: 0, fontSize: '12px', lineHeight: 1.4 }}
+                                disabled={!gistID}
+                                as="a"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                href={gistUrl || '#'}
+                                onClick={(e: React.MouseEvent) => { if (!gistID) e.preventDefault(); }}
+                                title={gistID ? browser.i18n.getMessage('viewGistTitle') || `View "${gistFileName}" on GitHub` : (browser.i18n.getMessage('viewGistHint') || 'Save the Gist ID first')}
+                            >
+                                {browser.i18n.getMessage('viewGist') || 'View Gist'} ↗
+                            </Button>
+                        </div>
+                        <div className="form-help">{browser.i18n.getMessage('gistIDHelp') || '粘贴 Gist URL 中的 ID 部分（例如 gist.github.com/&lt;ID&gt;，只填 &lt;ID&gt; 这一段，不要带 URL）'}</div>
                     </Col>
                 </Form.Group>
                 <Form.Group as={Row}>
@@ -46,13 +216,175 @@ const Popup: React.FC = () => {
                             name="enableNotify"
                             ref={register}
                             type="switch"
+                            aria-label={browser.i18n.getMessage('enableNotifications') || 'Enable desktop notifications'}
                         />
                     </Col>
                 </Form.Group>
+
+                {/* =============== 自动同步区域 =============== */}
+                <hr />
+                <h5 style={{ marginTop: '1rem' }}>⏰ {browser.i18n.getMessage('autoSyncSection') || 'Scheduled Auto Sync'}</h5>
+
+                <Form.Group as={Row}>
+                    <Form.Label column="sm" sm={3} lg={2} xs={3}>{browser.i18n.getMessage('autoSyncEnable') || 'Enable Auto Sync'}</Form.Label>
+                    <Col sm={9} lg={10} xs={9}>
+                        <Form.Check
+                            id="enableAutoSync"
+                            name="enableAutoSync"
+                            ref={register}
+                            type="switch"
+                            label={browser.i18n.getMessage('autoSyncEnableDesc') || 'Sync bookmarks automatically on a schedule'}
+                        />
+                    </Col>
+                </Form.Group>
+
+                <Form.Group as={Row}>
+                    <Form.Label column="sm" sm={3} lg={2} xs={3}>{browser.i18n.getMessage('autoSyncInterval') || 'Interval'}</Form.Label>
+                    <Col sm={9} lg={10} xs={9}>
+                        <Form.Control
+                            as="select"
+                            name="autoSyncInterval"
+                            ref={register}
+                            size="sm"
+                            disabled={!enableAutoSync}
+                            style={{ maxWidth: '240px' }}
+                        >
+                            {INTERVAL_OPTIONS.map(opt => (
+                                <option key={opt.value} value={opt.value}>{opt.label}</option>
+                            ))}
+                        </Form.Control>
+                    </Col>
+                </Form.Group>
+
+                <Form.Group as={Row}>
+                    <Form.Label column="sm" sm={3} lg={2} xs={3}>{browser.i18n.getMessage('autoSyncDirection') || 'Sync Direction'}</Form.Label>
+                    <Col sm={9} lg={10} xs={9}>
+                        <Form.Control
+                            as="select"
+                            name="autoSyncDirection"
+                            ref={register}
+                            size="sm"
+                            disabled={!enableAutoSync}
+                            style={{ maxWidth: '240px' }}
+                        >
+                            <option value="bidirectional">{browser.i18n.getMessage('autoSyncDirBoth') || 'Bidirectional (download then upload)'}</option>
+                            <option value="upload">{browser.i18n.getMessage('autoSyncDirUpload') || 'Upload only (local → Gist)'}</option>
+                            <option value="download">{browser.i18n.getMessage('autoSyncDirDownload') || 'Download only (Gist → local)'}</option>
+                        </Form.Control>
+                    </Col>
+                </Form.Group>
+
+                <Form.Group as={Row}>
+                    <Form.Label column="sm" sm={3} lg={2} xs={3}>{browser.i18n.getMessage('autoSyncOnStartup') || 'On Browser Startup'}</Form.Label>
+                    <Col sm={9} lg={10} xs={9}>
+                        <Form.Check
+                            id="autoSyncOnStartup"
+                            name="autoSyncOnStartup"
+                            ref={register}
+                            type="switch"
+                            disabled={!enableAutoSync}
+                            label={browser.i18n.getMessage('autoSyncOnStartupDesc') || 'Trigger a sync immediately when browser starts'}
+                        />
+                    </Col>
+                </Form.Group>
+
+                <Form.Group as={Row}>
+                    <Form.Label column="sm" sm={3} lg={2} xs={3}>{browser.i18n.getMessage('autoSyncLastTime') || 'Last Auto Sync'}</Form.Label>
+                    <Col sm={9} lg={10} xs={9}>
+                        <div style={{ paddingTop: '6px', color: '#666' }}>
+                            {lastSyncText || '-'}
+                            <Button
+                                size="sm"
+                                variant="outline-primary"
+                                style={{ marginLeft: '12px' }}
+                                onClick={onRunNow}
+                            >
+                                {browser.i18n.getMessage('autoSyncRunNow') || 'Run Now'}
+                            </Button>
+                            <Button
+                                size="sm"
+                                variant="primary"
+                                style={{ marginLeft: '8px' }}
+                                onClick={onSave}
+                            >
+                                {browser.i18n.getMessage('autoSyncSave') || 'Save'}
+                            </Button>
+                        </div>
+                        {saveHint && <Alert variant="success" style={{ marginTop: '8px', padding: '6px 12px' }}>{saveHint}</Alert>}
+                        <Alert id="runNowHint" variant="info" style={{ marginTop: '8px', padding: '6px 12px', display: 'none' }}></Alert>
+                    </Col>
+                </Form.Group>
+
                 <Form.Group as={Row}>
                     <Form.Label column="sm" sm={3} lg={2} xs={3}></Form.Label>
                     <Col sm={9} lg={10} xs={9}>
                         <a href="https://github.com/dudor/BookmarkHub" target="_blank">{browser.i18n.getMessage('help')}</a>
+                    </Col>
+                </Form.Group>
+
+                {/* =============== 高级功能：AI 整理书签 =============== */}
+                <hr />
+                <h5 style={{ marginTop: '1rem' }}>{browser.i18n.getMessage('aiOrganizeSection') || '🤖 AI Organize Bookmarks'}</h5>
+
+                <Form.Group as={Row}>
+                    <Form.Label column="sm" sm={3} lg={2} xs={3}>{browser.i18n.getMessage('aiOrganizeBackendUrl') || 'Backend URL'}</Form.Label>
+                    <Col sm={9} lg={10} xs={9}>
+                        <Form.Control
+                            name="aiOrganizeBackendUrl"
+                            ref={register}
+                            type="text"
+                            placeholder="http://103.11.78.250:18903"
+                            size="sm"
+                        />
+                        <div className="form-help">{browser.i18n.getMessage('aiOrganizeBackendUrlHelp') || 'Default backend URL; change if self-hosted'}</div>
+                    </Col>
+                </Form.Group>
+
+                <Form.Group as={Row}>
+                    <Form.Label column="sm" sm={3} lg={2} xs={3}>🤖</Form.Label>
+                    <Col sm={9} lg={10} xs={9}>
+                        <Button
+                            size="sm"
+                            variant="primary"
+                            id="aiOrganizeStartBtn"
+                            disabled={!!aiIsRunning || aiStartPending}
+                            onClick={async () => {
+                                const btn = document.getElementById('aiOrganizeStartBtn') as HTMLButtonElement;
+                                const hint = document.getElementById('aiOrganizeHint');
+                                const setHint = (text: string, variant: 'info' | 'success' | 'danger' = 'info') => {
+                                    if (!hint) return;
+                                    hint.textContent = text;
+                                    hint.className = `alert alert-${variant}`;
+                                    hint.style.display = 'block';
+                                };
+                                try {
+                                    setAiStartPending(true);
+                                    // 先保存当前配置（包含新填的 backend URL）
+                                    await optionsStorage.setAll(getValues());
+                                    const r: any = await browser.runtime.sendMessage({ name: 'aiOrganizeStart' });
+                                    if (r?.ok) {
+                                        // 注意：整理过程中不再自动弹出 popup，避免干扰用户
+                                        // popup 会在任务完成后由 background 自动弹出，显示结果详情
+                                        setHint(browser.i18n.getMessage('aiOrganizeStartHint') || '✅ 任务已启动，整理完成后会自动弹出结果窗口', 'success');
+                                    } else {
+                                        setHint('❌ ' + (r?.error || 'Failed to start'), 'danger');
+                                    }
+                                } catch (e: any) {
+                                    setHint('❌ ' + (e?.message || String(e)), 'danger');
+                                } finally {
+                                    setAiStartPending(false);
+                                }
+                            }}
+                        >
+                            {aiIsRunning
+                                ? (browser.i18n.getMessage('aiOrganizeRunning') || 'AI 整理中…')
+                                : (browser.i18n.getMessage('aiOrganizeRunButton') || '开始整理')}
+                        </Button>
+                        <div style={{ fontSize: 11, color: '#888', marginTop: 6, lineHeight: 1.4 }}>
+                            {browser.i18n.getMessage('aiOrganizeModalHint') || 'Will create an AIOrganized folder in your Gist. Click "Download Bookmarks" in popup after it completes.'}
+                        </div>
+                        <Alert id="aiOrganizeHint" variant="info" style={{ marginTop: '8px', padding: '6px 12px', display: 'none' }}></Alert>
+                        {renderAiProgress()}
                     </Col>
                 </Form.Group>
             </Form>
@@ -66,4 +398,3 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       <Popup />
     </React.StrictMode>,
   );
-  

--- a/src/entrypoints/popup/popup.css
+++ b/src/entrypoints/popup/popup.css
@@ -1,8 +1,45 @@
-#root {
-    width: 15rem;
-    min-height: 11rem;
+/* BookmarkHub 弹框自适应布局
+ * 目标：浏览器能完整显示内容时，不出现上下、左右滚动条
+ *
+ * 策略：
+ * 1. html/body 不要设置固定 height/width，也不要默认 margin
+ * 2. #root 使用 inline-block（shrink-wrap）自然贴合内容
+ * 3. 用 min-width / max-width 限定宽度区间，避免极端情况
+ * 4. dropdown-menu 跟随 #root 宽度
+ */
+
+html,
+body {
+    margin: 0;
+    padding: 0;
+    overflow: visible;
+    width: auto;
     height: auto;
-    position: relative;
+}
+
+body {
+    /* 弹框宿主：根据内容自适应，不撑满视口 */
+    display: table;
+    min-width: 0;
+    min-height: 0;
+}
+
+#root {
+    /* 关键：inline-block 让元素 shrink-wrap 到内容尺寸 */
+    display: inline-block;
+    /* 宽度自适应内容 */
+    width: auto;
+    /* 最小宽度，避免空内容时弹框过窄 */
+    min-width: 14rem;
+    /* 最大宽度：限制为视口宽度的 90%，避免极宽显示器下弹框过宽 */
+    max-width: min(28rem, 90vw);
+    /* 高度由内容决定 */
+    height: auto;
+    min-height: 0;
+    /* 不产生滚动条 */
+    overflow: visible;
+    /* 包含子元素（处理 BFC） */
+    box-sizing: border-box;
 }
 
 .list-group-item {
@@ -17,7 +54,17 @@
     opacity: 1 !important;
     pointer-events: auto !important;
     border: none !important;
+    /* 跟随 #root 的自适应宽度 */
     width: 100% !important;
+    /* 弹框内菜单也自适应，不出现竖向滚动条 */
+    max-height: none;
+    overflow: visible;
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    /* 显式声明在文档流中（不被绝对定位抢走 #root 高度） */
+    position: static !important;
+    transform: none !important;
 }
 
 .dropdown-item,
@@ -25,16 +72,196 @@
     font-size: 12px !important;
     padding: .5rem 1rem !important;
     vertical-align: middle !important;
+    /* 长文本不换行也不溢出 */
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    /* flex 让图标和文字垂直居中 */
+    display: flex !important;
+    align-items: center;
+    gap: 6px;
 }
 
 .dropdown-item-icon {
     vertical-align: middle;
-    margin-right: 5px;
+    margin-right: 0;
     width: 1.1rem;
     height: 1.1rem;
+    flex-shrink: 0;
 }
 
 .dropdown-item a,
 .dropdown-item-text a {
     color: inherit;
+}
+
+/* =============== 同步时间行（无刷新按钮） =============== */
+.popup-last-sync {
+    /* 跟其它 ItemText 一致，但更小一些 */
+    font-size: 11px !important;
+    padding: .25rem 1rem !important;
+    /* 跟下面的 footer 用更浅的灰色分隔 */
+    border-top: 1px dashed rgba(0, 0, 0, 0.08);
+    color: #555;
+    /* 让它在窄弹框里能换行 */
+    white-space: normal !important;
+    overflow: visible !important;
+    text-overflow: clip !important;
+    line-height: 1.4;
+}
+
+/* 已同步时间：普通灰 */
+.sync-time-real {
+    color: #333;
+    font-weight: 500;
+}
+
+/* 还未更新：红色斜体，醒目提示 */
+.sync-time-not-yet {
+    color: #d9534f;
+    font-style: italic;
+    font-weight: 500;
+}
+
+/* 触发源标签：auto 绿底，manual 蓝底 */
+.sync-source {
+    display: inline-block;
+    padding: 0 4px;
+    border-radius: 3px;
+    font-size: 10px;
+    font-weight: 600;
+    line-height: 1.4;
+    margin-left: 2px;
+    vertical-align: middle;
+}
+.sync-source-auto {
+    background: #d4edda;
+    color: #155724;
+}
+.sync-source-manual {
+    background: #d1ecf1;
+    color: #0c5460;
+}
+
+/* =============== AI 整理书签：进度条 / 提示 =============== */
+.ai-organize-progress {
+    /* 顶部小条，限制宽度跟随 popup */
+    padding: 8px 12px 6px 12px;
+    background: linear-gradient(135deg, #eef2ff 0%, #f5f3ff 100%);
+    border-bottom: 1px solid #c7d2fe;
+    font-size: 12px;
+    color: #312e81;
+    box-sizing: border-box;
+}
+
+.ai-organize-progress-title {
+    font-weight: 600;
+    font-size: 12px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.ai-organize-progress-text {
+    font-size: 11px;
+    color: #4f46e5;
+    margin-top: 2px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.ai-organize-hint {
+    padding: 4px 12px;
+    background: #d4edda;
+    color: #155724;
+    font-size: 11px;
+    text-align: center;
+    border-bottom: 1px solid #c3e6cb;
+}
+
+/* =============== AI 整理结果模态框 =============== */
+.ai-organize-modal .modal-dialog {
+    /* popup 是个小窗口，模态框要适配 */
+    max-width: 22rem;
+    margin: 1rem auto;
+}
+
+.ai-organize-summary {
+    font-size: 14px;
+    font-weight: 600;
+    color: #1e293b;
+    margin-bottom: 10px;
+    padding: 8px 10px;
+    background: #f0fdf4;
+    border-left: 3px solid #22c55e;
+    border-radius: 3px;
+}
+
+.ai-organize-cat-list {
+    max-height: 180px;
+    overflow-y: auto;
+    border: 1px solid #e2e8f0;
+    border-radius: 4px;
+    padding: 4px 0;
+    background: #fafafa;
+}
+
+.ai-organize-cat-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 4px 10px;
+    font-size: 12px;
+    border-bottom: 1px solid #f1f5f9;
+}
+.ai-organize-cat-row:last-child {
+    border-bottom: none;
+}
+.ai-organize-cat-row:nth-child(odd) {
+    background: #f8fafc;
+}
+
+.ai-organize-cat-name {
+    color: #334155;
+    font-weight: 500;
+}
+
+.ai-organize-cat-count {
+    color: #6366f1;
+    font-weight: 600;
+    font-size: 11px;
+    background: #eef2ff;
+    padding: 1px 8px;
+    border-radius: 10px;
+}
+
+.ai-organize-hint-line {
+    margin-top: 10px;
+    padding: 6px 10px;
+    background: #fffbeb;
+    border-left: 3px solid #f59e0b;
+    font-size: 11px;
+    color: #78350f;
+    border-radius: 3px;
+    line-height: 1.4;
+}
+
+.ai-organize-error {
+    padding: 10px;
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+    border-radius: 4px;
+    color: #991b1b;
+    font-size: 12px;
+    word-break: break-word;
+    line-height: 1.5;
+    font-family: 'SF Mono', Consolas, monospace;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+/* 弹窗里的按钮"在弹窗中点立即同步" - 高亮"下载书签" */
+.ai-organize-modal .modal-footer {
+    justify-content: flex-end;
 }

--- a/src/entrypoints/popup/popup.tsx
+++ b/src/entrypoints/popup/popup.tsx
@@ -1,53 +1,317 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import ReactDOM from 'react-dom/client';
-import { Dropdown, Badge } from 'react-bootstrap';
+import { Dropdown, Badge, Modal, Button } from 'react-bootstrap';
 import { IconContext } from 'react-icons'
 import {
     AiOutlineCloudUpload, AiOutlineCloudDownload,
     AiOutlineCloudSync, AiOutlineSetting, AiOutlineClear,
-    AiOutlineInfoCircle, AiOutlineGithub
+    AiOutlineInfoCircle, AiOutlineGithub, AiOutlineRobot
 } from 'react-icons/ai'
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './popup.css'
+
+type LastSyncState = {
+    ts: number;            // 时间戳（毫秒），0 = 从未同步
+    source: 'auto' | 'manual' | 'none';
+};
+
+type AIOrganizeProgress = {
+    current: number;
+    total: number;
+    current_step: string;
+    message: string;
+};
+
+type AIOrganizeState = {
+    task_id: string | null;
+    status: 'pending' | 'running' | 'success' | 'failed';
+    progress: AIOrganizeProgress;
+    result: {
+        total_bookmarks?: number;
+        category_count?: number;
+        categories?: { category: string; count: number }[];
+        organized_root?: string;
+    } | null;
+    error: string | null;
+    started_at: number;
+    finished_at: number | null;
+    dismissed?: boolean;
+};
+
 const Popup: React.FC = () => {
     const [count, setCount] = useState({ local: "0", remote: "0" })
+    const [lastSync, setLastSync] = useState<LastSyncState>({ ts: 0, source: 'none' });
+    const [aiState, setAiState] = useState<AIOrganizeState | null>(null);
+    const [showAiModal, setShowAiModal] = useState(false);
+    const [aiRunningHint, setAiRunningHint] = useState(false);  // 启动任务的瞬时反馈
+    const pollTimerRef = useRef<any>(null);
+
     useEffect(() => {
         document.addEventListener('click', (e: MouseEvent) => {
             let elem = e.target as HTMLInputElement;
             if (elem != null && elem.className === 'dropdown-item') {
                 elem.setAttribute('disabled', 'disabled');
                 browser.runtime.sendMessage({ name: elem.name })
-                    .then((res) => {
+                    .then(async (_res) => {
                         elem.removeAttribute('disabled');
-                        console.log("msg", Date.now())
+                        console.log("msg", Date.now());
+                        if (elem.name === 'upload' || elem.name === 'download') {
+                            await loadLastSync();
+                        }
                     })
                     .catch(c => {
-                        console.log("error", c)
+                        console.log("error", c);
                     });
             }
         });
     }, [])
+
     useEffect(() => {
         let getSetting = async () => {
-            let data = await browser.storage.local.get(["localCount", "remoteCount"]);
+            let data = await browser.storage.local.get(["localCount", "remoteCount", "lastSyncAt", "lastSyncSource"]);
             setCount({ local: data["localCount"], remote: data["remoteCount"] });
+            setLastSync({
+                ts: data["lastSyncAt"] || 0,
+                source: data["lastSyncSource"] || 'none',
+            });
         }
         getSetting();
     }, [])
+
+    /**
+     * AI 整理进度轮询：
+     *  - 每 1.5 秒拉一次后端状态
+     *  - running 期间持续刷新
+     *  - 终态时停止轮询 + 弹模态框
+     */
+    useEffect(() => {
+        const tick = async () => {
+            try {
+                const r: any = await browser.runtime.sendMessage({ name: 'aiOrganizeGetState' });
+                if (r?.ok && r.state) {
+                    setAiState(r.state);
+                    if ((r.state.status === 'success' || r.state.status === 'failed') && !r.state.dismissed) {
+                        setShowAiModal(true);
+                    }
+                } else {
+                    setAiState(null);
+                }
+            } catch (e) {
+                // ignore
+            }
+        };
+        tick();
+        pollTimerRef.current = setInterval(tick, 1500);
+        return () => {
+            if (pollTimerRef.current) clearInterval(pollTimerRef.current);
+        };
+    }, []);
+
+    /**
+     * 重新加载 lastSyncAt。手动触发同步后调用。
+     */
+    const loadLastSync = async () => {
+        const data = await browser.storage.local.get(["lastSyncAt", "lastSyncSource"]);
+        setLastSync({
+            ts: data["lastSyncAt"] || 0,
+            source: data["lastSyncSource"] || 'none',
+        });
+    };
+
+    /**
+     * 触发 AI 整理任务
+     */
+    const handleAiOrganize = async (e: any) => {
+        e.preventDefault();
+        e.stopPropagation();
+        // 防止重复点击：running 或 pending 时直接 return（按钮本身已 disabled）
+        if (aiState && (aiState.status === 'running' || aiState.status === 'pending')) return;
+        if (aiRunningHint) return;
+        setAiRunningHint(true);
+        try {
+            const r: any = await browser.runtime.sendMessage({ name: 'aiOrganizeStart' });
+            if (r?.ok) {
+                // 立即拉一次状态（不等 1.5s 轮询），让进度条立即出现
+                const s: any = await browser.runtime.sendMessage({ name: 'aiOrganizeGetState' });
+                if (s?.ok && s.state) setAiState(s.state);
+            } else {
+                alert(r?.error || 'Failed to start');
+            }
+        } catch (e: any) {
+            alert(String(e?.message || e));
+        } finally {
+            setAiRunningHint(false);
+        }
+    };
+
+    /**
+     * 关闭 AI 整理结果模态框 + 清除 storage
+     */
+    const handleCloseAiModal = async () => {
+        setShowAiModal(false);
+        try {
+            await browser.runtime.sendMessage({ name: 'aiOrganizeClearState' });
+        } catch (e) { /* ignore */ }
+        setAiState(null);
+    };
+
+    /**
+     * 渲染同步时间行
+     */
+    const renderLastSync = () => {
+        const label = browser.i18n.getMessage('lastSync') || 'Last Sync';
+        if (!lastSync.ts) {
+            const notYet = browser.i18n.getMessage('lastSyncNotYet') || 'Not yet updated';
+            return (
+                <>
+                    {label}: <span className="sync-time-not-yet">{notYet}</span>
+                </>
+            );
+        }
+        const dateStr = new Date(lastSync.ts).toLocaleString();
+        const sourceKey = lastSync.source === 'auto' ? 'lastSyncSourceAuto' : 'lastSyncSourceManual';
+        const sourceDefault = lastSync.source === 'auto' ? 'Auto' : 'Manual';
+        const sourceLabel = browser.i18n.getMessage(sourceKey) || sourceDefault;
+        return (
+            <>
+                {label}: <span className="sync-time-real">{dateStr}</span>{' '}
+                <span className={`sync-source sync-source-${lastSync.source}`}>[{sourceLabel}]</span>
+            </>
+        );
+    };
+
+    /**
+     * 渲染 AI 整理进度条（仅在 running 时显示）
+     */
+    const renderAiProgress = () => {
+        if (!aiState || aiState.status !== 'running') return null;
+        const pct = aiState.progress.total > 0
+            ? Math.min(100, Math.round((aiState.progress.current / aiState.progress.total) * 100))
+            : 0;
+        const labelTpl = browser.i18n.getMessage('aiOrganizeProgressLabel') || '{current} / {total} done ({step})';
+        const label = labelTpl
+            .replace('{current}', String(aiState.progress.current))
+            .replace('{total}', String(aiState.progress.total || '?'))
+            .replace('{step}', aiState.progress.current_step || '');
+
+        return (
+            <div className="ai-organize-progress">
+                <div className="ai-organize-progress-title">
+                    {browser.i18n.getMessage('aiOrganizeRunningTitle') || '🤖 AI Organizing…'}
+                </div>
+                <div className="progress" style={{ height: 6, marginTop: 4, marginBottom: 4 }}>
+                    <div
+                        className="progress-bar progress-bar-striped progress-bar-animated"
+                        style={{ width: `${pct}%`, backgroundColor: '#6366f1' }}
+                    />
+                </div>
+                <div className="ai-organize-progress-text">{label}</div>
+            </div>
+        );
+    };
+
+    /**
+     * 重置 AI 整理 storage 状态（用于任务卡住时的逃生口）
+     */
+    const handleAiReset = async () => {
+        if (!confirm('确定要清除 AI 整理状态吗？\n（仅在任务卡住时使用，会取消后端任务的本地跟踪，不会停止后端真实任务）')) return;
+        try {
+            await browser.runtime.sendMessage({ name: 'aiOrganizeClearState' });
+            setAiState(null);
+            setShowAiModal(false);
+        } catch (e) { /* ignore */ }
+    };
+
     return (
         <IconContext.Provider value={{ className: 'dropdown-item-icon' }}>
+            {renderAiProgress()}
             <Dropdown.Menu show>
                 <Dropdown.Item name='upload' as="button" title={browser.i18n.getMessage('uploadBookmarksDesc')}><AiOutlineCloudUpload />{browser.i18n.getMessage('uploadBookmarks')}</Dropdown.Item>
                 <Dropdown.Item name='download' as="button" title={browser.i18n.getMessage('downloadBookmarksDesc')}><AiOutlineCloudDownload />{browser.i18n.getMessage('downloadBookmarks')}</Dropdown.Item>
                 <Dropdown.Item name='removeAll' as="button" title={browser.i18n.getMessage('removeAllBookmarksDesc')}><AiOutlineClear />{browser.i18n.getMessage('removeAllBookmarks')}</Dropdown.Item>
                 <Dropdown.Divider />
+                <Dropdown.Item
+                    as="button"
+                    onClick={handleAiOrganize}
+                    disabled={aiRunningHint || (aiState?.status === 'running' || aiState?.status === 'pending')}
+                    title={browser.i18n.getMessage('aiOrganizeRunButton')}
+                >
+                    <AiOutlineRobot />{aiState && (aiState.status === 'running' || aiState.status === 'pending')
+                        ? (browser.i18n.getMessage('aiOrganizeRunning') || 'AI 整理中…')
+                        : (browser.i18n.getMessage('aiOrganizeRunButton') || 'AI Organize')}
+                </Dropdown.Item>
+                {aiState && (aiState.status === 'running' || aiState.status === 'pending') && (
+                    <Dropdown.Item
+                        as="button"
+                        onClick={handleAiReset}
+                        style={{ fontSize: 11, color: '#888' }}
+                        title="卡住时点此重置"
+                    >
+                        ⚠️ 任务卡住了？点这里重置
+                    </Dropdown.Item>
+                )}
+                <Dropdown.Divider />
                 <Dropdown.Item name='setting' as="button"><AiOutlineSetting />{browser.i18n.getMessage('settings')}</Dropdown.Item>
+                <Dropdown.ItemText className="popup-last-sync">
+                    {renderLastSync()}
+                </Dropdown.ItemText>
                 <Dropdown.ItemText>
                     <AiOutlineInfoCircle /><a href="https://github.com/dudor/BookmarkHub" target="_blank">{browser.i18n.getMessage('help')}</a>|
                     <Badge id="localCount" variant="light" title={browser.i18n.getMessage('localCount')}>{count["local"]}</Badge>/<Badge id="remoteCount" variant="light" title={browser.i18n.getMessage('remoteCount')}>{count["remote"]}</Badge>|
                     <a href="https://github.com/dudor" target="_blank" title={browser.i18n.getMessage('author')}><AiOutlineGithub /></a>
                 </Dropdown.ItemText>
             </Dropdown.Menu >
+
+            {/* AI 整理结果模态框 */}
+            <Modal
+                show={showAiModal}
+                onHide={handleCloseAiModal}
+                backdrop="static"
+                size="sm"
+                centered
+                className="ai-organize-modal"
+            >
+                <Modal.Header closeButton>
+                    <Modal.Title style={{ fontSize: '16px' }}>
+                        {aiState?.status === 'success'
+                            ? (browser.i18n.getMessage('aiOrganizeModalTitle') || '🎉 Organize Complete')
+                            : (browser.i18n.getMessage('aiOrganizeFailed') || '❌ Organize Failed')}
+                    </Modal.Title>
+                </Modal.Header>
+                <Modal.Body style={{ padding: '12px 16px' }}>
+                    {aiState?.status === 'success' && aiState.result ? (
+                        <>
+                            <div className="ai-organize-summary">
+                                {(browser.i18n.getMessage('aiOrganizeModalSummary') || 'Organized {count} bookmarks into {cats} categories')
+                                    .replace('{count}', String(aiState.result.total_bookmarks || 0))
+                                    .replace('{cats}', String(aiState.result.category_count || 0))}
+                            </div>
+                            {aiState.result.categories && aiState.result.categories.length > 0 && (
+                                <div className="ai-organize-cat-list">
+                                    {aiState.result.categories.map((c, i) => (
+                                        <div key={i} className="ai-organize-cat-row">
+                                            <span className="ai-organize-cat-name">{c.category}</span>
+                                            <span className="ai-organize-cat-count">{c.count}</span>
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                            <div className="ai-organize-hint-line">
+                                {browser.i18n.getMessage('aiOrganizeModalHint') || 'Click "Sync Now" in the popup to see the result.'}
+                            </div>
+                        </>
+                    ) : (
+                        <div className="ai-organize-error">
+                            {aiState?.error || 'Unknown error'}
+                        </div>
+                    )}
+                </Modal.Body>
+                <Modal.Footer style={{ padding: '8px 16px' }}>
+                    <Button variant="primary" size="sm" onClick={handleCloseAiModal}>
+                        {browser.i18n.getMessage('aiOrganizeModalClose') || 'Close'}
+                    </Button>
+                </Modal.Footer>
+            </Modal>
         </IconContext.Provider>
     )
 }
@@ -58,5 +322,3 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
         <Popup />
     </React.StrictMode>,
 );
-
-

--- a/src/public/_locales/ar/messages.json
+++ b/src/public/_locales/ar/messages.json
@@ -1,90 +1,307 @@
 {
-    "extensionName": {
-        "message": "BookmarkHub - مزامنة العلامات المرجعية",
-        "description": ""
-    },
-    "extensionDescription": {
-        "message": "BookmarkHub، مزامنة العلامات المرجعية عبر متصفحات مختلفة",
-        "description": ""
-    },
-    "uploadBookmarks": {
-        "message": "رفع العلامات المرجعية",
-        "description": ""
-    },
-    "downloadBookmarks": {
-        "message": "تنزيل العلامات المرجعية",
-        "description": ""
-    },
-    "syncBookmarks": {
-        "message": "مزامنة العلامات المرجعية",
-        "description": ""
-    },
-    "removeAllBookmarks": {
-        "message": "إزالة جميع العلامات المرجعية",
-        "description": ""
-    },
-    "settings": {
-        "message": "الإعدادات",
-        "description": ""
-    },
-    "help": {
-        "message": "المساعدة",
-        "description": ""
-    },
-    "localCount": {
-        "message": "عدد العلامات المرجعية المحلية",
-        "description": ""
-    },
-    "remoteCount": {
-        "message": "عدد العلامات المرجعية البعيدة",
-        "description": ""
-    },
-    "githubToken": {
-        "message": "رمز GitHub",
-        "description": ""
-    },
-    "gistID": {
-        "message": "معرف Gist",
-        "description": ""
-    },
-    "gistFileName": {
-        "message": "اسم ملف Gist",
-        "description": ""
-    },
-    "enableNotifications": {
-        "message": "تمكين الإشعارات",
-        "description": ""
-    },
-    "success": {
-        "message": "نجاح",
-        "description": ""
-    },
-    "failed": {
-        "message": "فشل",
-        "description": ""
-    },
-    "error": {
-        "message": "خطأ",
-        "description": ""
-    },
-    "author": {
-        "message": "المؤلف",
-        "description": ""
-    },
-    "uploadBookmarksDesc": {
-        "message": "رفع جميع العلامات المرجعية في المتصفح المحلي إلى الخادم",
-        "description": ""
-    },
-    "downloadBookmarksDesc": {
-        "message": "أزل العلامات المرجعية في المتصفح المحلي أولاً، ثم قم بتنزيل جميع العلامات المرجعية على الخادم إلى المتصفح المحلي",
-        "description": ""
-    },
-    "syncBookmarksDesc": {
-        "message": "دمج جميع العلامات المرجعية على الخادم في المتصفح المحلي، ثم قم بتحميلها إلى الخادم",
-        "description": ""
-    },
-    "removeAllBookmarksDesc": {
-        "message": "أزل جميع العلامات المرجعية. يرجى إجراء نسخ احتياطي أولاً",
-        "description": ""
-    }
+	"extensionName": {
+		"message": "BookmarkHub - مزامنة العلامات المرجعية",
+		"description": ""
+	},
+	"extensionDescription": {
+		"message": "BookmarkHub، مزامنة العلامات المرجعية عبر متصفحات مختلفة",
+		"description": ""
+	},
+	"uploadBookmarks": {
+		"message": "رفع العلامات المرجعية",
+		"description": ""
+	},
+	"downloadBookmarks": {
+		"message": "تنزيل العلامات المرجعية",
+		"description": ""
+	},
+	"syncBookmarks": {
+		"message": "مزامنة العلامات المرجعية",
+		"description": ""
+	},
+	"removeAllBookmarks": {
+		"message": "إزالة جميع العلامات المرجعية",
+		"description": ""
+	},
+	"settings": {
+		"message": "الإعدادات",
+		"description": ""
+	},
+	"help": {
+		"message": "المساعدة",
+		"description": ""
+	},
+	"localCount": {
+		"message": "عدد العلامات المرجعية المحلية",
+		"description": ""
+	},
+	"remoteCount": {
+		"message": "عدد العلامات المرجعية البعيدة",
+		"description": ""
+	},
+	"githubToken": {
+		"message": "رمز GitHub",
+		"description": ""
+	},
+	"gistID": {
+		"message": "معرف Gist",
+		"description": ""
+	},
+	"gistFileName": {
+		"message": "اسم ملف Gist",
+		"description": ""
+	},
+	"enableNotifications": {
+		"message": "تمكين الإشعارات",
+		"description": ""
+	},
+	"success": {
+		"message": "نجاح",
+		"description": ""
+	},
+	"failed": {
+		"message": "فشل",
+		"description": ""
+	},
+	"error": {
+		"message": "خطأ",
+		"description": ""
+	},
+	"author": {
+		"message": "المؤلف",
+		"description": ""
+	},
+	"uploadBookmarksDesc": {
+		"message": "رفع جميع العلامات المرجعية في المتصفح المحلي إلى الخادم",
+		"description": ""
+	},
+	"downloadBookmarksDesc": {
+		"message": "أزل العلامات المرجعية في المتصفح المحلي أولاً، ثم قم بتنزيل جميع العلامات المرجعية على الخادم إلى المتصفح المحلي",
+		"description": ""
+	},
+	"syncBookmarksDesc": {
+		"message": "دمج جميع العلامات المرجعية على الخادم في المتصفح المحلي، ثم قم بتحميلها إلى الخادم",
+		"description": ""
+	},
+	"removeAllBookmarksDesc": {
+		"message": "أزل جميع العلامات المرجعية. يرجى إجراء نسخ احتياطي أولاً",
+		"description": ""
+	},
+	"autoSyncTitle": {
+		"message": "Scheduled Auto Sync",
+		"description": ""
+	},
+	"autoSyncMissingConfig": {
+		"message": "Please fill in Token / Gist ID / File Name in settings first",
+		"description": ""
+	},
+	"autoSyncSection": {
+		"message": "Scheduled Auto Sync",
+		"description": ""
+	},
+	"autoSyncEnable": {
+		"message": "Enable Auto Sync",
+		"description": ""
+	},
+	"autoSyncEnableDesc": {
+		"message": "Sync bookmarks between local and Gist on a schedule",
+		"description": ""
+	},
+	"autoSyncInterval": {
+		"message": "Sync Interval",
+		"description": ""
+	},
+	"autoSyncDirection": {
+		"message": "Sync Direction",
+		"description": ""
+	},
+	"autoSyncDirBoth": {
+		"message": "Bidirectional (download then upload)",
+		"description": ""
+	},
+	"autoSyncDirUpload": {
+		"message": "Upload only (local → Gist)",
+		"description": ""
+	},
+	"autoSyncDirDownload": {
+		"message": "Download only (Gist → local)",
+		"description": ""
+	},
+	"autoSyncOnStartup": {
+		"message": "Sync on Browser Startup",
+		"description": ""
+	},
+	"autoSyncOnStartupDesc": {
+		"message": "Trigger a sync immediately when browser starts",
+		"description": ""
+	},
+	"autoSyncLastTime": {
+		"message": "Last Auto Sync",
+		"description": ""
+	},
+	"autoSyncRunNow": {
+		"message": "Run Now",
+		"description": ""
+	},
+	"autoSyncSave": {
+		"message": "Save",
+		"description": ""
+	},
+	"autoSyncSaved": {
+		"message": "Saved, auto sync settings applied",
+		"description": ""
+	},
+	"autoSyncSaveError": {
+		"message": "Saved, but failed to notify background",
+		"description": ""
+	},
+	"autoSyncNever": {
+		"message": "Never",
+		"description": ""
+	},
+	"lastSync": {
+		"message": "Last Sync",
+		"description": ""
+	},
+	"lastSyncNotYet": {
+		"message": "Not yet updated",
+		"description": ""
+	},
+	"lastSyncSourceAuto": {
+		"message": "Auto",
+		"description": ""
+	},
+	"lastSyncSourceManual": {
+		"message": "Manual",
+		"description": ""
+	},
+	"autoSyncInterval_15m": {
+		"message": "15 minutes",
+		"description": "Auto sync interval option: 15 minutes"
+	},
+	"autoSyncInterval_30m": {
+		"message": "30 minutes",
+		"description": "Auto sync interval option: 30 minutes"
+	},
+	"autoSyncInterval_1h": {
+		"message": "1 hour",
+		"description": "Auto sync interval option: 1 hour"
+	},
+	"autoSyncInterval_2h": {
+		"message": "2 hours",
+		"description": "Auto sync interval option: 2 hours"
+	},
+	"autoSyncInterval_6h": {
+		"message": "6 hours",
+		"description": "Auto sync interval option: 6 hours"
+	},
+	"autoSyncInterval_12h": {
+		"message": "12 hours",
+		"description": "Auto sync interval option: 12 hours"
+	},
+	"autoSyncInterval_24h": {
+		"message": "24 hours",
+		"description": "Auto sync interval option: 24 hours"
+	},
+	"autoSyncInterval_48h": {
+		"message": "48 hours",
+		"description": "Auto sync interval option: 48 hours"
+	},
+	"autoSyncInterval_72h": {
+		"message": "72 hours",
+		"description": "Auto sync interval option: 72 hours"
+	},
+	"autoSyncRunning": {
+		"message": "⏳ Syncing..."
+	},
+	"autoSyncRunSuccess": {
+		"message": "✅ Synced at "
+	},
+	"autoSyncRunDone": {
+		"message": "✅ Sync completed"
+	},
+	"autoSyncRunError": {
+		"message": "❌ Sync failed: "
+	},
+	"viewGist": {
+		"message": "عرض Gist"
+	},
+	"viewGistTitle": {
+		"message": "عرض ملف الإشارات المرجعية المتزامن على GitHub"
+	},
+	"viewGistHint": {
+		"message": "أدخل معرف Gist أولاً"
+	},
+	"githubTokenHelp": {
+		"message": "يلزم وجود رمز وصول شخصي (كلاسيكي) بنطاق 'gist'.",
+		"description": "تلميح يظهر أسفل حقل رمز GitHub"
+	},
+	"getToken": {
+		"message": "الحصول على رمز",
+		"description": "زر لفتح صفحة إعدادات رمز GitHub"
+	},
+	"createNewGist": {
+		"message": "📝 إنشاء Gist جديد",
+		"description": "رابط لإنشاء Gist جديد في gist.github.com"
+	},
+	"gistIDHelp": {
+		"message": "الصق فقط جزء المعرف من عنوان URL لـ Gist (على سبيل المثال، لـ gist.github.com/<ID>، انسخ جزء <ID> فقط، وليس عنوان URL الكامل).",
+		"description": "تلميح يظهر أسفل حقل معرف Gist"
+	},
+	"aiOrganizeSection": {
+		"message": "🤖 تنظيم الإشارات المرجعية بالذكاء الاصطناعي",
+		"description": "Options page advanced features section title"
+	},
+	"aiOrganizeBackendUrl": {
+		"message": "رابط خادم الذكاء الاصطناعي",
+		"description": "Label for the backend service URL input in advanced features"
+	},
+	"aiOrganizeBackendUrlHelp": {
+		"message": "الافتراضي http://103.11.78.250:18903. غيّره إذا كنت تستضيف الخادم بنفسك.",
+		"description": "Help text shown below the backend URL input"
+	},
+	"aiOrganizeRunButton": {
+		"message": "تنظيم الإشارات المرجعية",
+		"description": "Button that triggers the AI organize task"
+	},
+	"aiOrganizeRunningTitle": {
+		"message": "🤖 جارٍ التنظيم بالذكاء الاصطناعي…",
+		"description": "Title of the progress bar shown in the popup during the task"
+	},
+	"aiOrganizeProgressLabel": {
+		"message": "تم {current} / {total} ({step})",
+		"description": "Progress text template; {current}/{total} done, {step} shown"
+	},
+	"aiOrganizeModalTitle": {
+		"message": "🎉 اكتمل التنظيم",
+		"description": "Title of the success modal shown after organizing completes"
+	},
+	"aiOrganizeModalSummary": {
+		"message": "تم تنظيم {count} إشارة مرجعية في {cats} فئات",
+		"description": "Summary line in the success modal; {count} bookmarks in {cats} categories"
+	},
+	"aiOrganizeModalHint": {
+		"message": "تم التنظيم في المجلد الجذر 「AI分类」 في Gist. انقر على \"تنزيل الإشارات المرجعية\" في النافذة المنبثقة للمزامنة.",
+		"description": "Hint shown in the success modal telling user to download via popup"
+	},
+	"aiOrganizeModalClose": {
+		"message": "إغلاق",
+		"description": "Close button label on the success/failure modal"
+	},
+	"aiOrganizeFailed": {
+		"message": "❌ فشل التنظيم",
+		"description": "Title of the failure modal shown when the AI organize task fails"
+	},
+	"aiOrganizeMissingConfig": {
+		"message": "يرجى تكوين Token / Gist ID / اسم الملف أولاً",
+		"description": "Error message when token/gist/file-name config is missing"
+	},
+	"aiOrganizeStartHint": {
+		"message": "✅ Started. Results window will pop up automatically when done.",
+		"description": "Toast message shown after successfully starting the AI organize task"
+	},
+	"aiOrganizeRunning": {
+		"message": "الذكاء الاصطناعي ينظّم…",
+		"description": "Label shown on the Organize button while a task is running"
+	}
 }

--- a/src/public/_locales/de/messages.json
+++ b/src/public/_locales/de/messages.json
@@ -1,90 +1,307 @@
 {
-    "extensionName": {
-        "message": "BookmarkHub - Bookmark-Synchronisierung",
-        "description": ""
-    },
-    "extensionDescription": {
-        "message": "BookmarkHub, Synchronisierung von Bookmarks zwischen verschiedenen Browsern",
-        "description": ""
-    },
-    "uploadBookmarks": {
-        "message": "Bookmarks hochladen",
-        "description": ""
-    },
-    "downloadBookmarks": {
-        "message": "Bookmarks herunterladen",
-        "description": ""
-    },
-    "syncBookmarks": {
-        "message": "Bookmarks synchronisieren",
-        "description": ""
-    },
-    "removeAllBookmarks": {
-        "message": "Alle Bookmarks löschen",
-        "description": ""
-    },
-    "settings": {
-        "message": "Einstellungen",
-        "description": ""
-    },
-    "help": {
-        "message": "Hilfe",
-        "description": ""
-    },
-    "localCount": {
-        "message": "Anzahl lokaler Bookmarks",
-        "description": ""
-    },
-    "remoteCount": {
-        "message": "Anzahl entfernter Bookmarks",
-        "description": ""
-    },
-    "githubToken": {
-        "message": "GitHub-Token",
-        "description": ""
-    },
-    "gistID": {
-        "message": "Gist-ID",
-        "description": ""
-    },
-    "gistFileName": {
-        "message": "Gist-Dateiname",
-        "description": ""
-    },
-    "enableNotifications": {
-        "message": "Benachrichtigungen aktivieren",
-        "description": ""
-    },
-    "success": {
-        "message": "Erfolg",
-        "description": ""
-    },
-    "failed": {
-        "message": "Fehlschlag",
-        "description": ""
-    },
-    "error": {
-        "message": "Fehler",
-        "description": ""
-    },
-    "author": {
-        "message": "Autor",
-        "description": ""
-    },
-    "uploadBookmarksDesc": {
-        "message": "Alle Bookmarks des lokalen Browsers auf den Server hochladen",
-        "description": ""
-    },
-    "downloadBookmarksDesc": {
-        "message": "Zunächst die Bookmarks des lokalen Browsers löschen und dann alle Bookmarks vom Server in den lokalen Browser herunterladen",
-        "description": ""
-    },
-    "syncBookmarksDesc": {
-        "message": "Alle Bookmarks vom Server in den lokalen Browser zusammenführen und dann auf den Server hochladen",
-        "description": ""
-    },
-    "removeAllBookmarksDesc": {
-        "message": "Alle Bookmarks löschen. Bitte erstellen Sie vorher ein Backup.",
-        "description": ""
-    }
+	"extensionName": {
+		"message": "BookmarkHub - Bookmark-Synchronisierung",
+		"description": ""
+	},
+	"extensionDescription": {
+		"message": "BookmarkHub, Synchronisierung von Bookmarks zwischen verschiedenen Browsern",
+		"description": ""
+	},
+	"uploadBookmarks": {
+		"message": "Bookmarks hochladen",
+		"description": ""
+	},
+	"downloadBookmarks": {
+		"message": "Bookmarks herunterladen",
+		"description": ""
+	},
+	"syncBookmarks": {
+		"message": "Bookmarks synchronisieren",
+		"description": ""
+	},
+	"removeAllBookmarks": {
+		"message": "Alle Bookmarks löschen",
+		"description": ""
+	},
+	"settings": {
+		"message": "Einstellungen",
+		"description": ""
+	},
+	"help": {
+		"message": "Hilfe",
+		"description": ""
+	},
+	"localCount": {
+		"message": "Anzahl lokaler Bookmarks",
+		"description": ""
+	},
+	"remoteCount": {
+		"message": "Anzahl entfernter Bookmarks",
+		"description": ""
+	},
+	"githubToken": {
+		"message": "GitHub-Token",
+		"description": ""
+	},
+	"gistID": {
+		"message": "Gist-ID",
+		"description": ""
+	},
+	"gistFileName": {
+		"message": "Gist-Dateiname",
+		"description": ""
+	},
+	"enableNotifications": {
+		"message": "Benachrichtigungen aktivieren",
+		"description": ""
+	},
+	"success": {
+		"message": "Erfolg",
+		"description": ""
+	},
+	"failed": {
+		"message": "Fehlschlag",
+		"description": ""
+	},
+	"error": {
+		"message": "Fehler",
+		"description": ""
+	},
+	"author": {
+		"message": "Autor",
+		"description": ""
+	},
+	"uploadBookmarksDesc": {
+		"message": "Alle Bookmarks des lokalen Browsers auf den Server hochladen",
+		"description": ""
+	},
+	"downloadBookmarksDesc": {
+		"message": "Zunächst die Bookmarks des lokalen Browsers löschen und dann alle Bookmarks vom Server in den lokalen Browser herunterladen",
+		"description": ""
+	},
+	"syncBookmarksDesc": {
+		"message": "Alle Bookmarks vom Server in den lokalen Browser zusammenführen und dann auf den Server hochladen",
+		"description": ""
+	},
+	"removeAllBookmarksDesc": {
+		"message": "Alle Bookmarks löschen. Bitte erstellen Sie vorher ein Backup.",
+		"description": ""
+	},
+	"autoSyncTitle": {
+		"message": "Scheduled Auto Sync",
+		"description": ""
+	},
+	"autoSyncMissingConfig": {
+		"message": "Please fill in Token / Gist ID / File Name in settings first",
+		"description": ""
+	},
+	"autoSyncSection": {
+		"message": "Scheduled Auto Sync",
+		"description": ""
+	},
+	"autoSyncEnable": {
+		"message": "Enable Auto Sync",
+		"description": ""
+	},
+	"autoSyncEnableDesc": {
+		"message": "Sync bookmarks between local and Gist on a schedule",
+		"description": ""
+	},
+	"autoSyncInterval": {
+		"message": "Sync Interval",
+		"description": ""
+	},
+	"autoSyncDirection": {
+		"message": "Sync Direction",
+		"description": ""
+	},
+	"autoSyncDirBoth": {
+		"message": "Bidirectional (download then upload)",
+		"description": ""
+	},
+	"autoSyncDirUpload": {
+		"message": "Upload only (local → Gist)",
+		"description": ""
+	},
+	"autoSyncDirDownload": {
+		"message": "Download only (Gist → local)",
+		"description": ""
+	},
+	"autoSyncOnStartup": {
+		"message": "Sync on Browser Startup",
+		"description": ""
+	},
+	"autoSyncOnStartupDesc": {
+		"message": "Trigger a sync immediately when browser starts",
+		"description": ""
+	},
+	"autoSyncLastTime": {
+		"message": "Last Auto Sync",
+		"description": ""
+	},
+	"autoSyncRunNow": {
+		"message": "Run Now",
+		"description": ""
+	},
+	"autoSyncSave": {
+		"message": "Save",
+		"description": ""
+	},
+	"autoSyncSaved": {
+		"message": "Saved, auto sync settings applied",
+		"description": ""
+	},
+	"autoSyncSaveError": {
+		"message": "Saved, but failed to notify background",
+		"description": ""
+	},
+	"autoSyncNever": {
+		"message": "Never",
+		"description": ""
+	},
+	"lastSync": {
+		"message": "Last Sync",
+		"description": ""
+	},
+	"lastSyncNotYet": {
+		"message": "Not yet updated",
+		"description": ""
+	},
+	"lastSyncSourceAuto": {
+		"message": "Auto",
+		"description": ""
+	},
+	"lastSyncSourceManual": {
+		"message": "Manual",
+		"description": ""
+	},
+	"autoSyncInterval_15m": {
+		"message": "15 minutes",
+		"description": "Auto sync interval option: 15 minutes"
+	},
+	"autoSyncInterval_30m": {
+		"message": "30 minutes",
+		"description": "Auto sync interval option: 30 minutes"
+	},
+	"autoSyncInterval_1h": {
+		"message": "1 hour",
+		"description": "Auto sync interval option: 1 hour"
+	},
+	"autoSyncInterval_2h": {
+		"message": "2 hours",
+		"description": "Auto sync interval option: 2 hours"
+	},
+	"autoSyncInterval_6h": {
+		"message": "6 hours",
+		"description": "Auto sync interval option: 6 hours"
+	},
+	"autoSyncInterval_12h": {
+		"message": "12 hours",
+		"description": "Auto sync interval option: 12 hours"
+	},
+	"autoSyncInterval_24h": {
+		"message": "24 hours",
+		"description": "Auto sync interval option: 24 hours"
+	},
+	"autoSyncInterval_48h": {
+		"message": "48 hours",
+		"description": "Auto sync interval option: 48 hours"
+	},
+	"autoSyncInterval_72h": {
+		"message": "72 hours",
+		"description": "Auto sync interval option: 72 hours"
+	},
+	"autoSyncRunning": {
+		"message": "⏳ Syncing..."
+	},
+	"autoSyncRunSuccess": {
+		"message": "✅ Synced at "
+	},
+	"autoSyncRunDone": {
+		"message": "✅ Sync completed"
+	},
+	"autoSyncRunError": {
+		"message": "❌ Sync failed: "
+	},
+	"viewGist": {
+		"message": "Gist ansehen"
+	},
+	"viewGistTitle": {
+		"message": "Synchronisierte Lesezeichen-Datei auf GitHub ansehen"
+	},
+	"viewGistHint": {
+		"message": "Bitte zuerst Gist-ID eingeben"
+	},
+	"githubTokenHelp": {
+		"message": "Ein Personal Access Token (classic) mit 'gist'-Berechtigung ist erforderlich.",
+		"description": "Hinweis unter dem GitHub-Token-Feld"
+	},
+	"getToken": {
+		"message": "Token holen",
+		"description": "Schaltfläche zum Öffnen der GitHub-Token-Einstellungen"
+	},
+	"createNewGist": {
+		"message": "📝 Neuen Gist erstellen",
+		"description": "Link zum Erstellen eines neuen Gists auf gist.github.com"
+	},
+	"gistIDHelp": {
+		"message": "Fügen Sie nur den ID-Teil Ihrer Gist-URL ein (z. B. für gist.github.com/<ID> nur den <ID>-Teil, nicht die vollständige URL).",
+		"description": "Hinweis unter dem Gist-ID-Feld"
+	},
+	"aiOrganizeSection": {
+		"message": "🤖 KI-Lesezeichen organisieren",
+		"description": "Options page advanced features section title"
+	},
+	"aiOrganizeBackendUrl": {
+		"message": "KI-Backend-URL",
+		"description": "Label for the backend service URL input in advanced features"
+	},
+	"aiOrganizeBackendUrlHelp": {
+		"message": "Standard http://103.11.78.250:18903. Ändern Sie dies, wenn Sie das Backend selbst hosten.",
+		"description": "Help text shown below the backend URL input"
+	},
+	"aiOrganizeRunButton": {
+		"message": "Lesezeichen organisieren",
+		"description": "Button that triggers the AI organize task"
+	},
+	"aiOrganizeRunningTitle": {
+		"message": "🤖 KI-Organisation läuft…",
+		"description": "Title of the progress bar shown in the popup during the task"
+	},
+	"aiOrganizeProgressLabel": {
+		"message": "{current} / {total} erledigt ({step})",
+		"description": "Progress text template; {current}/{total} done, {step} shown"
+	},
+	"aiOrganizeModalTitle": {
+		"message": "🎉 Organisation abgeschlossen",
+		"description": "Title of the success modal shown after organizing completes"
+	},
+	"aiOrganizeModalSummary": {
+		"message": "{count} Lesezeichen in {cats} Kategorien organisiert",
+		"description": "Summary line in the success modal; {count} bookmarks in {cats} categories"
+	},
+	"aiOrganizeModalHint": {
+		"message": "Im Wurzelordner 「AI分类」 Ihres Gists organisiert. Klicken Sie im Popup auf \"Lesezeichen herunterladen\", um zu synchronisieren.",
+		"description": "Hint shown in the success modal telling user to download via popup"
+	},
+	"aiOrganizeModalClose": {
+		"message": "Schließen",
+		"description": "Close button label on the success/failure modal"
+	},
+	"aiOrganizeFailed": {
+		"message": "❌ Organisation fehlgeschlagen",
+		"description": "Title of the failure modal shown when the AI organize task fails"
+	},
+	"aiOrganizeMissingConfig": {
+		"message": "Bitte zuerst Token / Gist-ID / Dateiname konfigurieren",
+		"description": "Error message when token/gist/file-name config is missing"
+	},
+	"aiOrganizeStartHint": {
+		"message": "✅ Started. Results window will pop up automatically when done.",
+		"description": "Toast message shown after successfully starting the AI organize task"
+	},
+	"aiOrganizeRunning": {
+		"message": "KI organisiert…",
+		"description": "Label shown on the Organize button while a task is running"
+	}
 }

--- a/src/public/_locales/en/messages.json
+++ b/src/public/_locales/en/messages.json
@@ -1,90 +1,307 @@
 {
-    "extensionName": {
-        "message": "BookmarkHub - sync bookmarks ",
-        "description": ""
-    },
-    "extensionDescription": {
-        "message": "BookmarkHub,sync bookmarks across different browsers",
-        "description": ""
-    },
-    "uploadBookmarks": {
-        "message": "Upload Bookmarks",
-        "description": ""
-    },
-    "downloadBookmarks": {
-        "message": "DownLoad Bookmarks",
-        "description": ""
-    },
-    "syncBookmarks": {
-        "message": "Sync Bookmarks",
-        "description": ""
-    },
-    "removeAllBookmarks": {
-        "message": "Remove All Bookmarks",
-        "description": ""
-    },
-    "settings": {
-        "message": "Settings",
-        "description": ""
-    },
-    "help": {
-        "message": "Help",
-        "description": ""
-    },
-    "localCount": {
-        "message": "Local Bookmark Count",
-        "description": ""
-    },
-    "remoteCount": {
-        "message": "Remote Bookmark Count",
-        "description": ""
-    },
-    "githubToken": {
-        "message": "Github Token",
-        "description": ""
-    },
-    "gistID": {
-        "message": "Gist ID",
-        "description": ""
-    },
-    "gistFileName": {
-        "message": "Gist File Name",
-        "description": ""
-    },
-    "enableNotifications": {
-        "message": "Enable Notifications",
-        "description": ""
-    },
-    "success": {
-        "message": "Success",
-        "description": ""
-    },
-    "failed": {
-        "message": "Failed",
-        "description": ""
-    },
-    "error": {
-        "message": "Error",
-        "description": ""
-    },
-    "author": {
-        "message": "Author",
-        "description": ""
-    },
-    "uploadBookmarksDesc": {
-        "message": "Upload all the bookmarks of the local browser to the server",
-        "description": ""
-    },
-    "downloadBookmarksDesc": {
-        "message": "First clear the bookmarks in the local browser, and then download all the bookmarks on the server to the local browser",
-        "description": ""
-    },
-    "syncBookmarksDesc": {
-        "message": "Merge all the bookmarks on the server into the local browser, and then upload them to the server",
-        "description": ""
-    },
-    "removeAllBookmarksDesc": {
-        "message": "Remove All Bookmarks, Please backup first",
-        "description": ""
-    }
+	"extensionName": {
+		"message": "BookmarkHub - sync bookmarks ",
+		"description": ""
+	},
+	"extensionDescription": {
+		"message": "BookmarkHub,sync bookmarks across different browsers",
+		"description": ""
+	},
+	"uploadBookmarks": {
+		"message": "Upload Bookmarks",
+		"description": ""
+	},
+	"downloadBookmarks": {
+		"message": "DownLoad Bookmarks",
+		"description": ""
+	},
+	"syncBookmarks": {
+		"message": "Sync Bookmarks",
+		"description": ""
+	},
+	"removeAllBookmarks": {
+		"message": "Remove All Bookmarks",
+		"description": ""
+	},
+	"settings": {
+		"message": "Settings",
+		"description": ""
+	},
+	"help": {
+		"message": "Help",
+		"description": ""
+	},
+	"localCount": {
+		"message": "Local Bookmark Count",
+		"description": ""
+	},
+	"remoteCount": {
+		"message": "Remote Bookmark Count",
+		"description": ""
+	},
+	"githubToken": {
+		"message": "Github Token",
+		"description": ""
+	},
+	"gistID": {
+		"message": "Gist ID",
+		"description": ""
+	},
+	"gistFileName": {
+		"message": "Gist File Name",
+		"description": ""
+	},
+	"enableNotifications": {
+		"message": "Enable Notifications",
+		"description": ""
+	},
+	"success": {
+		"message": "Success",
+		"description": ""
+	},
+	"failed": {
+		"message": "Failed",
+		"description": ""
+	},
+	"error": {
+		"message": "Error",
+		"description": ""
+	},
+	"author": {
+		"message": "Author",
+		"description": ""
+	},
+	"uploadBookmarksDesc": {
+		"message": "Upload all the bookmarks of the local browser to the server",
+		"description": ""
+	},
+	"downloadBookmarksDesc": {
+		"message": "First clear the bookmarks in the local browser, and then download all the bookmarks on the server to the local browser",
+		"description": ""
+	},
+	"syncBookmarksDesc": {
+		"message": "Merge all the bookmarks on the server into the local browser, and then upload them to the server",
+		"description": ""
+	},
+	"removeAllBookmarksDesc": {
+		"message": "Remove All Bookmarks, Please backup first",
+		"description": ""
+	},
+	"autoSyncTitle": {
+		"message": "Scheduled Auto Sync",
+		"description": ""
+	},
+	"autoSyncMissingConfig": {
+		"message": "Please fill in Token / Gist ID / File Name in settings first",
+		"description": ""
+	},
+	"autoSyncSection": {
+		"message": "Scheduled Auto Sync",
+		"description": ""
+	},
+	"autoSyncEnable": {
+		"message": "Enable Auto Sync",
+		"description": ""
+	},
+	"autoSyncEnableDesc": {
+		"message": "Sync bookmarks between local and Gist on a schedule",
+		"description": ""
+	},
+	"autoSyncInterval": {
+		"message": "Sync Interval",
+		"description": ""
+	},
+	"autoSyncDirection": {
+		"message": "Sync Direction",
+		"description": ""
+	},
+	"autoSyncDirBoth": {
+		"message": "Bidirectional (download then upload)",
+		"description": ""
+	},
+	"autoSyncDirUpload": {
+		"message": "Upload only (local → Gist)",
+		"description": ""
+	},
+	"autoSyncDirDownload": {
+		"message": "Download only (Gist → local)",
+		"description": ""
+	},
+	"autoSyncOnStartup": {
+		"message": "Sync on Browser Startup",
+		"description": ""
+	},
+	"autoSyncOnStartupDesc": {
+		"message": "Trigger a sync immediately when browser starts",
+		"description": ""
+	},
+	"autoSyncLastTime": {
+		"message": "Last Auto Sync",
+		"description": ""
+	},
+	"autoSyncRunNow": {
+		"message": "Run Now",
+		"description": ""
+	},
+	"autoSyncSave": {
+		"message": "Save",
+		"description": ""
+	},
+	"autoSyncSaved": {
+		"message": "Saved, auto sync settings applied",
+		"description": ""
+	},
+	"autoSyncSaveError": {
+		"message": "Saved, but failed to notify background",
+		"description": ""
+	},
+	"autoSyncNever": {
+		"message": "Never",
+		"description": ""
+	},
+	"lastSync": {
+		"message": "Last Sync",
+		"description": "Popup sync time row label, e.g. 'Last Sync: 2026-06-22 06:45'"
+	},
+	"lastSyncNotYet": {
+		"message": "Not yet updated",
+		"description": "Shown when no sync has happened yet; styled red italic"
+	},
+	"lastSyncSourceAuto": {
+		"message": "Auto",
+		"description": "Badge indicating the sync was triggered by the scheduled alarm (trigger source 01)"
+	},
+	"lastSyncSourceManual": {
+		"message": "Manual",
+		"description": "Badge indicating the sync was triggered by clicking upload/download (trigger source 02)"
+	},
+	"autoSyncInterval_15m": {
+		"message": "15 minutes",
+		"description": "Auto sync interval option: 15 minutes"
+	},
+	"autoSyncInterval_30m": {
+		"message": "30 minutes",
+		"description": "Auto sync interval option: 30 minutes"
+	},
+	"autoSyncInterval_1h": {
+		"message": "1 hour",
+		"description": "Auto sync interval option: 1 hour"
+	},
+	"autoSyncInterval_2h": {
+		"message": "2 hours",
+		"description": "Auto sync interval option: 2 hours"
+	},
+	"autoSyncInterval_6h": {
+		"message": "6 hours",
+		"description": "Auto sync interval option: 6 hours"
+	},
+	"autoSyncInterval_12h": {
+		"message": "12 hours",
+		"description": "Auto sync interval option: 12 hours"
+	},
+	"autoSyncInterval_24h": {
+		"message": "24 hours",
+		"description": "Auto sync interval option: 24 hours"
+	},
+	"autoSyncInterval_48h": {
+		"message": "48 hours",
+		"description": "Auto sync interval option: 48 hours"
+	},
+	"autoSyncInterval_72h": {
+		"message": "72 hours",
+		"description": "Auto sync interval option: 72 hours"
+	},
+	"autoSyncRunning": {
+		"message": "⏳ Syncing..."
+	},
+	"autoSyncRunSuccess": {
+		"message": "✅ Synced at "
+	},
+	"autoSyncRunDone": {
+		"message": "✅ Sync completed"
+	},
+	"autoSyncRunError": {
+		"message": "❌ Sync failed: "
+	},
+	"viewGist": {
+		"message": "View Gist"
+	},
+	"viewGistTitle": {
+		"message": "View the synced bookmarks file on GitHub"
+	},
+	"viewGistHint": {
+		"message": "Save the Gist ID first"
+	},
+	"githubTokenHelp": {
+		"message": "A Personal Access Token (classic) with the 'gist' scope is required.",
+		"description": "Hint shown below the GitHub Token field"
+	},
+	"getToken": {
+		"message": "Get Token",
+		"description": "Button to open GitHub token settings page"
+	},
+	"createNewGist": {
+		"message": "📝 Create new Gist",
+		"description": "Link to open gist.github.com to create a new Gist"
+	},
+	"gistIDHelp": {
+		"message": "Paste only the ID portion from your Gist URL (e.g. for gist.github.com/<ID>, copy just the <ID> part, not the full URL).",
+		"description": "Hint shown below the Gist ID field"
+	},
+	"aiOrganizeSection": {
+		"message": "🤖 AI Organize Bookmarks",
+		"description": "Options page advanced features section title"
+	},
+	"aiOrganizeBackendUrl": {
+		"message": "AI Organize Backend URL",
+		"description": "Label for the backend service URL input in advanced features"
+	},
+	"aiOrganizeBackendUrlHelp": {
+		"message": "Default http://103.11.78.250:18903. Change this if you self-host the backend.",
+		"description": "Help text shown below the backend URL input"
+	},
+	"aiOrganizeRunButton": {
+		"message": "Organize Bookmarks",
+		"description": "Button that triggers the AI organize task"
+	},
+	"aiOrganizeRunningTitle": {
+		"message": "🤖 AI Organizing…",
+		"description": "Title of the progress bar shown in the popup during the task"
+	},
+	"aiOrganizeProgressLabel": {
+		"message": "{current} / {total} done ({step})",
+		"description": "Progress text template: {current} done count, {total} total, {step} current step name"
+	},
+	"aiOrganizeModalTitle": {
+		"message": "🎉 Organize Complete",
+		"description": "Title of the modal shown after organize task succeeds"
+	},
+	"aiOrganizeModalSummary": {
+		"message": "Organized {count} bookmarks into {cats} categories",
+		"description": "Modal summary: {count} bookmark count, {cats} category count"
+	},
+	"aiOrganizeModalHint": {
+		"message": "Organized into the 「AI分类」 root folder in your Gist. Click \"Download Bookmarks\" in the popup to sync to your browser.",
+		"description": "Hint at the bottom of the success modal"
+	},
+	"aiOrganizeModalClose": {
+		"message": "Close",
+		"description": "Modal close button"
+	},
+	"aiOrganizeFailed": {
+		"message": "❌ Organize Failed",
+		"description": "Title of the modal shown when the organize task fails"
+	},
+	"aiOrganizeMissingConfig": {
+		"message": "Please configure Token / Gist ID / File Name first",
+		"description": "Hint shown when the user hasn't filled in required config"
+	},
+	"aiOrganizeStartHint": {
+		"message": "✅ Started. Results window will pop up automatically when done.",
+		"description": "Hint shown on options page after clicking the organize button"
+	},
+	"aiOrganizeRunning": {
+		"message": "AI Organizing…",
+		"description": "Label shown on the Organize button while a task is running"
+	}
 }

--- a/src/public/_locales/es/messages.json
+++ b/src/public/_locales/es/messages.json
@@ -1,90 +1,307 @@
 {
-    "extensionName": {
-        "message": "BookmarkHub - Sincronización de marcadores",
-        "description": ""
-    },
-    "extensionDescription": {
-        "message": "BookmarkHub, sincronización de marcadores entre diferentes navegadores",
-        "description": ""
-    },
-    "uploadBookmarks": {
-        "message": "Subir marcadores",
-        "description": ""
-    },
-    "downloadBookmarks": {
-        "message": "Descargar marcadores",
-        "description": ""
-    },
-    "syncBookmarks": {
-        "message": "Sincronizar marcadores",
-        "description": ""
-    },
-    "removeAllBookmarks": {
-        "message": "Eliminar todos los marcadores",
-        "description": ""
-    },
-    "settings": {
-        "message": "Configuración",
-        "description": ""
-    },
-    "help": {
-        "message": "Ayuda",
-        "description": ""
-    },
-    "localCount": {
-        "message": "Cantidad de marcadores locales",
-        "description": ""
-    },
-    "remoteCount": {
-        "message": "Cantidad de marcadores remotos",
-        "description": ""
-    },
-    "githubToken": {
-        "message": "Token de GitHub",
-        "description": ""
-    },
-    "gistID": {
-        "message": "ID de Gist",
-        "description": ""
-    },
-    "gistFileName": {
-        "message": "Nombre de archivo de Gist",
-        "description": ""
-    },
-    "enableNotifications": {
-        "message": "Activar notificaciones",
-        "description": ""
-    },
-    "success": {
-        "message": "Éxito",
-        "description": ""
-    },
-    "failed": {
-        "message": "Fracaso",
-        "description": ""
-    },
-    "error": {
-        "message": "Error",
-        "description": ""
-    },
-    "author": {
-        "message": "Autor",
-        "description": ""
-    },
-    "uploadBookmarksDesc": {
-        "message": "Subir todos los marcadores del navegador local al servidor",
-        "description": ""
-    },
-    "downloadBookmarksDesc": {
-        "message": "Eliminar primero los marcadores del navegador local y luego descargar todos los marcadores del servidor al navegador local",
-        "description": ""
-    },
-    "syncBookmarksDesc": {
-        "message": "Combinar todos los marcadores del servidor en el navegador local y luego subirlos al servidor",
-        "description": ""
-    },
-    "removeAllBookmarksDesc": {
-        "message": "Eliminar todos los marcadores. Por favor, realice una copia de seguridad primero.",
-        "description": ""
-    }
+	"extensionName": {
+		"message": "BookmarkHub - Sincronización de marcadores",
+		"description": ""
+	},
+	"extensionDescription": {
+		"message": "BookmarkHub, sincronización de marcadores entre diferentes navegadores",
+		"description": ""
+	},
+	"uploadBookmarks": {
+		"message": "Subir marcadores",
+		"description": ""
+	},
+	"downloadBookmarks": {
+		"message": "Descargar marcadores",
+		"description": ""
+	},
+	"syncBookmarks": {
+		"message": "Sincronizar marcadores",
+		"description": ""
+	},
+	"removeAllBookmarks": {
+		"message": "Eliminar todos los marcadores",
+		"description": ""
+	},
+	"settings": {
+		"message": "Configuración",
+		"description": ""
+	},
+	"help": {
+		"message": "Ayuda",
+		"description": ""
+	},
+	"localCount": {
+		"message": "Cantidad de marcadores locales",
+		"description": ""
+	},
+	"remoteCount": {
+		"message": "Cantidad de marcadores remotos",
+		"description": ""
+	},
+	"githubToken": {
+		"message": "Token de GitHub",
+		"description": ""
+	},
+	"gistID": {
+		"message": "ID de Gist",
+		"description": ""
+	},
+	"gistFileName": {
+		"message": "Nombre de archivo de Gist",
+		"description": ""
+	},
+	"enableNotifications": {
+		"message": "Activar notificaciones",
+		"description": ""
+	},
+	"success": {
+		"message": "Éxito",
+		"description": ""
+	},
+	"failed": {
+		"message": "Fracaso",
+		"description": ""
+	},
+	"error": {
+		"message": "Error",
+		"description": ""
+	},
+	"author": {
+		"message": "Autor",
+		"description": ""
+	},
+	"uploadBookmarksDesc": {
+		"message": "Subir todos los marcadores del navegador local al servidor",
+		"description": ""
+	},
+	"downloadBookmarksDesc": {
+		"message": "Eliminar primero los marcadores del navegador local y luego descargar todos los marcadores del servidor al navegador local",
+		"description": ""
+	},
+	"syncBookmarksDesc": {
+		"message": "Combinar todos los marcadores del servidor en el navegador local y luego subirlos al servidor",
+		"description": ""
+	},
+	"removeAllBookmarksDesc": {
+		"message": "Eliminar todos los marcadores. Por favor, realice una copia de seguridad primero.",
+		"description": ""
+	},
+	"autoSyncTitle": {
+		"message": "Scheduled Auto Sync",
+		"description": ""
+	},
+	"autoSyncMissingConfig": {
+		"message": "Please fill in Token / Gist ID / File Name in settings first",
+		"description": ""
+	},
+	"autoSyncSection": {
+		"message": "Scheduled Auto Sync",
+		"description": ""
+	},
+	"autoSyncEnable": {
+		"message": "Enable Auto Sync",
+		"description": ""
+	},
+	"autoSyncEnableDesc": {
+		"message": "Sync bookmarks between local and Gist on a schedule",
+		"description": ""
+	},
+	"autoSyncInterval": {
+		"message": "Sync Interval",
+		"description": ""
+	},
+	"autoSyncDirection": {
+		"message": "Sync Direction",
+		"description": ""
+	},
+	"autoSyncDirBoth": {
+		"message": "Bidirectional (download then upload)",
+		"description": ""
+	},
+	"autoSyncDirUpload": {
+		"message": "Upload only (local → Gist)",
+		"description": ""
+	},
+	"autoSyncDirDownload": {
+		"message": "Download only (Gist → local)",
+		"description": ""
+	},
+	"autoSyncOnStartup": {
+		"message": "Sync on Browser Startup",
+		"description": ""
+	},
+	"autoSyncOnStartupDesc": {
+		"message": "Trigger a sync immediately when browser starts",
+		"description": ""
+	},
+	"autoSyncLastTime": {
+		"message": "Last Auto Sync",
+		"description": ""
+	},
+	"autoSyncRunNow": {
+		"message": "Run Now",
+		"description": ""
+	},
+	"autoSyncSave": {
+		"message": "Save",
+		"description": ""
+	},
+	"autoSyncSaved": {
+		"message": "Saved, auto sync settings applied",
+		"description": ""
+	},
+	"autoSyncSaveError": {
+		"message": "Saved, but failed to notify background",
+		"description": ""
+	},
+	"autoSyncNever": {
+		"message": "Never",
+		"description": ""
+	},
+	"lastSync": {
+		"message": "Last Sync",
+		"description": ""
+	},
+	"lastSyncNotYet": {
+		"message": "Not yet updated",
+		"description": ""
+	},
+	"lastSyncSourceAuto": {
+		"message": "Auto",
+		"description": ""
+	},
+	"lastSyncSourceManual": {
+		"message": "Manual",
+		"description": ""
+	},
+	"autoSyncInterval_15m": {
+		"message": "15 minutes",
+		"description": "Auto sync interval option: 15 minutes"
+	},
+	"autoSyncInterval_30m": {
+		"message": "30 minutes",
+		"description": "Auto sync interval option: 30 minutes"
+	},
+	"autoSyncInterval_1h": {
+		"message": "1 hour",
+		"description": "Auto sync interval option: 1 hour"
+	},
+	"autoSyncInterval_2h": {
+		"message": "2 hours",
+		"description": "Auto sync interval option: 2 hours"
+	},
+	"autoSyncInterval_6h": {
+		"message": "6 hours",
+		"description": "Auto sync interval option: 6 hours"
+	},
+	"autoSyncInterval_12h": {
+		"message": "12 hours",
+		"description": "Auto sync interval option: 12 hours"
+	},
+	"autoSyncInterval_24h": {
+		"message": "24 hours",
+		"description": "Auto sync interval option: 24 hours"
+	},
+	"autoSyncInterval_48h": {
+		"message": "48 hours",
+		"description": "Auto sync interval option: 48 hours"
+	},
+	"autoSyncInterval_72h": {
+		"message": "72 hours",
+		"description": "Auto sync interval option: 72 hours"
+	},
+	"autoSyncRunning": {
+		"message": "⏳ Syncing..."
+	},
+	"autoSyncRunSuccess": {
+		"message": "✅ Synced at "
+	},
+	"autoSyncRunDone": {
+		"message": "✅ Sync completed"
+	},
+	"autoSyncRunError": {
+		"message": "❌ Sync failed: "
+	},
+	"viewGist": {
+		"message": "Ver Gist"
+	},
+	"viewGistTitle": {
+		"message": "Ver el archivo de marcadores sincronizado en GitHub"
+	},
+	"viewGistHint": {
+		"message": "Introduce primero el ID de Gist"
+	},
+	"githubTokenHelp": {
+		"message": "Se requiere un Personal Access Token (classic) con el alcance 'gist'.",
+		"description": "Pista mostrada debajo del campo Token de GitHub"
+	},
+	"getToken": {
+		"message": "Obtener Token",
+		"description": "Botón para abrir la página de configuración de tokens de GitHub"
+	},
+	"createNewGist": {
+		"message": "📝 Crear nuevo Gist",
+		"description": "Enlace para crear un nuevo Gist en gist.github.com"
+	},
+	"gistIDHelp": {
+		"message": "Pegue solo la parte de la ID de la URL del Gist (p. ej., para gist.github.com/<ID>, copie solo la parte <ID>, no la URL completa).",
+		"description": "Pista mostrada debajo del campo ID de Gist"
+	},
+	"aiOrganizeSection": {
+		"message": "🤖 Organizar marcadores con IA",
+		"description": "Options page advanced features section title"
+	},
+	"aiOrganizeBackendUrl": {
+		"message": "URL del backend de IA",
+		"description": "Label for the backend service URL input in advanced features"
+	},
+	"aiOrganizeBackendUrlHelp": {
+		"message": "Predeterminado http://103.11.78.250:18903. Cámbielo si aloja su propio backend.",
+		"description": "Help text shown below the backend URL input"
+	},
+	"aiOrganizeRunButton": {
+		"message": "Organizar marcadores",
+		"description": "Button that triggers the AI organize task"
+	},
+	"aiOrganizeRunningTitle": {
+		"message": "🤖 Organizando con IA…",
+		"description": "Title of the progress bar shown in the popup during the task"
+	},
+	"aiOrganizeProgressLabel": {
+		"message": "{current} / {total} completados ({step})",
+		"description": "Progress text template; {current}/{total} done, {step} shown"
+	},
+	"aiOrganizeModalTitle": {
+		"message": "🎉 Organización completa",
+		"description": "Title of the success modal shown after organizing completes"
+	},
+	"aiOrganizeModalSummary": {
+		"message": "Se organizaron {count} marcadores en {cats} categorías",
+		"description": "Summary line in the success modal; {count} bookmarks in {cats} categories"
+	},
+	"aiOrganizeModalHint": {
+		"message": "Organizado en la carpeta raíz 「AI分类」 de tu Gist. Haz clic en \"Descargar marcadores\" en la popup para sincronizar.",
+		"description": "Hint shown in the success modal telling user to download via popup"
+	},
+	"aiOrganizeModalClose": {
+		"message": "Cerrar",
+		"description": "Close button label on the success/failure modal"
+	},
+	"aiOrganizeFailed": {
+		"message": "❌ Error al organizar",
+		"description": "Title of the failure modal shown when the AI organize task fails"
+	},
+	"aiOrganizeMissingConfig": {
+		"message": "Configure primero Token / ID de Gist / Nombre de archivo",
+		"description": "Error message when token/gist/file-name config is missing"
+	},
+	"aiOrganizeStartHint": {
+		"message": "✅ Started. Results window will pop up automatically when done.",
+		"description": "Toast message shown after successfully starting the AI organize task"
+	},
+	"aiOrganizeRunning": {
+		"message": "IA organizando…",
+		"description": "Label shown on the Organize button while a task is running"
+	}
 }

--- a/src/public/_locales/fr/messages.json
+++ b/src/public/_locales/fr/messages.json
@@ -1,90 +1,307 @@
 {
-    "extensionName": {
-        "message": "BookmarkHub - synchroniser les signets",
-        "description": ""
-    },
-    "extensionDescription": {
-        "message": "BookmarkHub, synchroniser les signets entre différents navigateurs",
-        "description": ""
-    },
-    "uploadBookmarks": {
-        "message": "Télécharger les signets",
-        "description": ""
-    },
-    "downloadBookmarks": {
-        "message": "Télécharger les signets",
-        "description": ""
-    },
-    "syncBookmarks": {
-        "message": "Synchroniser les signets",
-        "description": ""
-    },
-    "removeAllBookmarks": {
-        "message": "Supprimer tous les signets",
-        "description": ""
-    },
-    "settings": {
-        "message": "Paramètres",
-        "description": ""
-    },
-    "help": {
-        "message": "Aide",
-        "description": ""
-    },
-    "localCount": {
-        "message": "Nombre de signets locaux",
-        "description": ""
-    },
-    "remoteCount": {
-        "message": "Nombre de signets distants",
-        "description": ""
-    },
-    "githubToken": {
-        "message": "Jetons GitHub",
-        "description": ""
-    },
-    "gistID": {
-        "message": "ID Gist",
-        "description": ""
-    },
-    "gistFileName": {
-        "message": "Nom de fichier Gist",
-        "description": ""
-    },
-    "enableNotifications": {
-        "message": "Activer les notifications",
-        "description": ""
-    },
-    "success": {
-        "message": "Succès",
-        "description": ""
-    },
-    "failed": {
-        "message": "Échoué",
-        "description": ""
-    },
-    "error": {
-        "message": "Erreur",
-        "description": ""
-    },
-    "author": {
-        "message": "Auteur",
-        "description": ""
-    },
-    "uploadBookmarksDesc": {
-        "message": "Télécharger tous les signets du navigateur local vers le serveur",
-        "description": ""
-    },
-    "downloadBookmarksDesc": {
-        "message": "Supprimez d'abord les signets du navigateur local, puis téléchargez tous les signets du serveur vers le navigateur local",
-        "description": ""
-    },
-    "syncBookmarksDesc": {
-        "message": "Fusionnez tous les signets du serveur dans le navigateur local, puis téléchargez-les vers le serveur",
-        "description": ""
-    },
-    "removeAllBookmarksDesc": {
-        "message": "Supprimez tous les signets. Veuillez effectuer une sauvegarde au préalable.",
-        "description": ""
-    }
+	"extensionName": {
+		"message": "BookmarkHub - synchroniser les signets",
+		"description": ""
+	},
+	"extensionDescription": {
+		"message": "BookmarkHub, synchroniser les signets entre différents navigateurs",
+		"description": ""
+	},
+	"uploadBookmarks": {
+		"message": "Télécharger les signets",
+		"description": ""
+	},
+	"downloadBookmarks": {
+		"message": "Télécharger les signets",
+		"description": ""
+	},
+	"syncBookmarks": {
+		"message": "Synchroniser les signets",
+		"description": ""
+	},
+	"removeAllBookmarks": {
+		"message": "Supprimer tous les signets",
+		"description": ""
+	},
+	"settings": {
+		"message": "Paramètres",
+		"description": ""
+	},
+	"help": {
+		"message": "Aide",
+		"description": ""
+	},
+	"localCount": {
+		"message": "Nombre de signets locaux",
+		"description": ""
+	},
+	"remoteCount": {
+		"message": "Nombre de signets distants",
+		"description": ""
+	},
+	"githubToken": {
+		"message": "Jetons GitHub",
+		"description": ""
+	},
+	"gistID": {
+		"message": "ID Gist",
+		"description": ""
+	},
+	"gistFileName": {
+		"message": "Nom de fichier Gist",
+		"description": ""
+	},
+	"enableNotifications": {
+		"message": "Activer les notifications",
+		"description": ""
+	},
+	"success": {
+		"message": "Succès",
+		"description": ""
+	},
+	"failed": {
+		"message": "Échoué",
+		"description": ""
+	},
+	"error": {
+		"message": "Erreur",
+		"description": ""
+	},
+	"author": {
+		"message": "Auteur",
+		"description": ""
+	},
+	"uploadBookmarksDesc": {
+		"message": "Télécharger tous les signets du navigateur local vers le serveur",
+		"description": ""
+	},
+	"downloadBookmarksDesc": {
+		"message": "Supprimez d'abord les signets du navigateur local, puis téléchargez tous les signets du serveur vers le navigateur local",
+		"description": ""
+	},
+	"syncBookmarksDesc": {
+		"message": "Fusionnez tous les signets du serveur dans le navigateur local, puis téléchargez-les vers le serveur",
+		"description": ""
+	},
+	"removeAllBookmarksDesc": {
+		"message": "Supprimez tous les signets. Veuillez effectuer une sauvegarde au préalable.",
+		"description": ""
+	},
+	"autoSyncTitle": {
+		"message": "Scheduled Auto Sync",
+		"description": ""
+	},
+	"autoSyncMissingConfig": {
+		"message": "Please fill in Token / Gist ID / File Name in settings first",
+		"description": ""
+	},
+	"autoSyncSection": {
+		"message": "Scheduled Auto Sync",
+		"description": ""
+	},
+	"autoSyncEnable": {
+		"message": "Enable Auto Sync",
+		"description": ""
+	},
+	"autoSyncEnableDesc": {
+		"message": "Sync bookmarks between local and Gist on a schedule",
+		"description": ""
+	},
+	"autoSyncInterval": {
+		"message": "Sync Interval",
+		"description": ""
+	},
+	"autoSyncDirection": {
+		"message": "Sync Direction",
+		"description": ""
+	},
+	"autoSyncDirBoth": {
+		"message": "Bidirectional (download then upload)",
+		"description": ""
+	},
+	"autoSyncDirUpload": {
+		"message": "Upload only (local → Gist)",
+		"description": ""
+	},
+	"autoSyncDirDownload": {
+		"message": "Download only (Gist → local)",
+		"description": ""
+	},
+	"autoSyncOnStartup": {
+		"message": "Sync on Browser Startup",
+		"description": ""
+	},
+	"autoSyncOnStartupDesc": {
+		"message": "Trigger a sync immediately when browser starts",
+		"description": ""
+	},
+	"autoSyncLastTime": {
+		"message": "Last Auto Sync",
+		"description": ""
+	},
+	"autoSyncRunNow": {
+		"message": "Run Now",
+		"description": ""
+	},
+	"autoSyncSave": {
+		"message": "Save",
+		"description": ""
+	},
+	"autoSyncSaved": {
+		"message": "Saved, auto sync settings applied",
+		"description": ""
+	},
+	"autoSyncSaveError": {
+		"message": "Saved, but failed to notify background",
+		"description": ""
+	},
+	"autoSyncNever": {
+		"message": "Never",
+		"description": ""
+	},
+	"lastSync": {
+		"message": "Last Sync",
+		"description": ""
+	},
+	"lastSyncNotYet": {
+		"message": "Not yet updated",
+		"description": ""
+	},
+	"lastSyncSourceAuto": {
+		"message": "Auto",
+		"description": ""
+	},
+	"lastSyncSourceManual": {
+		"message": "Manual",
+		"description": ""
+	},
+	"autoSyncInterval_15m": {
+		"message": "15 minutes",
+		"description": "Auto sync interval option: 15 minutes"
+	},
+	"autoSyncInterval_30m": {
+		"message": "30 minutes",
+		"description": "Auto sync interval option: 30 minutes"
+	},
+	"autoSyncInterval_1h": {
+		"message": "1 hour",
+		"description": "Auto sync interval option: 1 hour"
+	},
+	"autoSyncInterval_2h": {
+		"message": "2 hours",
+		"description": "Auto sync interval option: 2 hours"
+	},
+	"autoSyncInterval_6h": {
+		"message": "6 hours",
+		"description": "Auto sync interval option: 6 hours"
+	},
+	"autoSyncInterval_12h": {
+		"message": "12 hours",
+		"description": "Auto sync interval option: 12 hours"
+	},
+	"autoSyncInterval_24h": {
+		"message": "24 hours",
+		"description": "Auto sync interval option: 24 hours"
+	},
+	"autoSyncInterval_48h": {
+		"message": "48 hours",
+		"description": "Auto sync interval option: 48 hours"
+	},
+	"autoSyncInterval_72h": {
+		"message": "72 hours",
+		"description": "Auto sync interval option: 72 hours"
+	},
+	"autoSyncRunning": {
+		"message": "⏳ Syncing..."
+	},
+	"autoSyncRunSuccess": {
+		"message": "✅ Synced at "
+	},
+	"autoSyncRunDone": {
+		"message": "✅ Sync completed"
+	},
+	"autoSyncRunError": {
+		"message": "❌ Sync failed: "
+	},
+	"viewGist": {
+		"message": "Voir le Gist"
+	},
+	"viewGistTitle": {
+		"message": "Voir le fichier de signets synchronisé sur GitHub"
+	},
+	"viewGistHint": {
+		"message": "Saisissez d'abord l'ID du Gist"
+	},
+	"githubTokenHelp": {
+		"message": "Un Personal Access Token (classic) avec le scope 'gist' est requis.",
+		"description": "Indice affiché sous le champ GitHub Token"
+	},
+	"getToken": {
+		"message": "Obtenir un Token",
+		"description": "Bouton pour ouvrir la page des paramètres de token GitHub"
+	},
+	"createNewGist": {
+		"message": "📝 Créer un nouveau Gist",
+		"description": "Lien pour ouvrir gist.github.com"
+	},
+	"gistIDHelp": {
+		"message": "Collez uniquement la partie ID de votre URL Gist (par ex. pour gist.github.com/<ID>, copiez juste la partie <ID>, pas l'URL complète).",
+		"description": "Indice affiché sous le champ Gist ID"
+	},
+	"aiOrganizeSection": {
+		"message": "🤖 Organiser les favoris par IA",
+		"description": "Options page advanced features section title"
+	},
+	"aiOrganizeBackendUrl": {
+		"message": "URL du backend IA",
+		"description": "Label for the backend service URL input in advanced features"
+	},
+	"aiOrganizeBackendUrlHelp": {
+		"message": "Par défaut http://103.11.78.250:18903. Modifiez cette valeur si vous auto-hébergez le backend.",
+		"description": "Help text shown below the backend URL input"
+	},
+	"aiOrganizeRunButton": {
+		"message": "Organiser les favoris",
+		"description": "Button that triggers the AI organize task"
+	},
+	"aiOrganizeRunningTitle": {
+		"message": "🤖 Organisation IA en cours…",
+		"description": "Title of the progress bar shown in the popup during the task"
+	},
+	"aiOrganizeProgressLabel": {
+		"message": "{current} / {total} terminés ({step})",
+		"description": "Progress text template; {current}/{total} done, {step} shown"
+	},
+	"aiOrganizeModalTitle": {
+		"message": "🎉 Organisation terminée",
+		"description": "Title of the success modal shown after organizing completes"
+	},
+	"aiOrganizeModalSummary": {
+		"message": "{count} favoris organisés en {cats} catégories",
+		"description": "Summary line in the success modal; {count} bookmarks in {cats} categories"
+	},
+	"aiOrganizeModalHint": {
+		"message": "Organisé dans le dossier racine 「AI分类」 de votre Gist. Cliquez sur « Télécharger les signets » dans la popup pour synchroniser.",
+		"description": "Hint shown in the success modal telling user to download via popup"
+	},
+	"aiOrganizeModalClose": {
+		"message": "Fermer",
+		"description": "Close button label on the success/failure modal"
+	},
+	"aiOrganizeFailed": {
+		"message": "❌ Échec de l'organisation",
+		"description": "Title of the failure modal shown when the AI organize task fails"
+	},
+	"aiOrganizeMissingConfig": {
+		"message": "Veuillez d'abord configurer Token / Gist ID / Nom de fichier",
+		"description": "Error message when token/gist/file-name config is missing"
+	},
+	"aiOrganizeStartHint": {
+		"message": "✅ Started. Results window will pop up automatically when done.",
+		"description": "Toast message shown after successfully starting the AI organize task"
+	},
+	"aiOrganizeRunning": {
+		"message": "IA en cours…",
+		"description": "Label shown on the Organize button while a task is running"
+	}
 }

--- a/src/public/_locales/it/messages.json
+++ b/src/public/_locales/it/messages.json
@@ -1,90 +1,307 @@
 {
-    "extensionName": {
-        "message": "BookmarkHub - Sincronizzazione segnalibri",
-        "description": ""
-    },
-    "extensionDescription": {
-        "message": "BookmarkHub, sincronizzazione dei segnalibri tra diversi browser",
-        "description": ""
-    },
-    "uploadBookmarks": {
-        "message": "Carica segnalibri",
-        "description": ""
-    },
-    "downloadBookmarks": {
-        "message": "Scarica segnalibri",
-        "description": ""
-    },
-    "syncBookmarks": {
-        "message": "Sincronizza segnalibri",
-        "description": ""
-    },
-    "removeAllBookmarks": {
-        "message": "Rimuovi tutti i segnalibri",
-        "description": ""
-    },
-    "settings": {
-        "message": "Impostazioni",
-        "description": ""
-    },
-    "help": {
-        "message": "Aiuto",
-        "description": ""
-    },
-    "localCount": {
-        "message": "Numero di segnalibri locali",
-        "description": ""
-    },
-    "remoteCount": {
-        "message": "Numero di segnalibri remoti",
-        "description": ""
-    },
-    "githubToken": {
-        "message": "Token GitHub",
-        "description": ""
-    },
-    "gistID": {
-        "message": "ID Gist",
-        "description": ""
-    },
-    "gistFileName": {
-        "message": "Nome file Gist",
-        "description": ""
-    },
-    "enableNotifications": {
-        "message": "Abilita notifiche",
-        "description": ""
-    },
-    "success": {
-        "message": "Successo",
-        "description": ""
-    },
-    "failed": {
-        "message": "Fallimento",
-        "description": ""
-    },
-    "error": {
-        "message": "Errore",
-        "description": ""
-    },
-    "author": {
-        "message": "Autore",
-        "description": ""
-    },
-    "uploadBookmarksDesc": {
-        "message": "Carica tutti i segnalibri del browser locale sul server",
-        "description": ""
-    },
-    "downloadBookmarksDesc": {
-        "message": "Elimina prima i segnalibri del browser locale e poi scarica tutti i segnalibri dal server sul browser locale",
-        "description": ""
-    },
-    "syncBookmarksDesc": {
-        "message": "Unisci tutti i segnalibri del server nel browser locale e poi caricali sul server",
-        "description": ""
-    },
-    "removeAllBookmarksDesc": {
-        "message": "Rimuovi tutti i segnalibri. Fai prima un backup.",
-        "description": ""
-    }
+	"extensionName": {
+		"message": "BookmarkHub - Sincronizzazione segnalibri",
+		"description": ""
+	},
+	"extensionDescription": {
+		"message": "BookmarkHub, sincronizzazione dei segnalibri tra diversi browser",
+		"description": ""
+	},
+	"uploadBookmarks": {
+		"message": "Carica segnalibri",
+		"description": ""
+	},
+	"downloadBookmarks": {
+		"message": "Scarica segnalibri",
+		"description": ""
+	},
+	"syncBookmarks": {
+		"message": "Sincronizza segnalibri",
+		"description": ""
+	},
+	"removeAllBookmarks": {
+		"message": "Rimuovi tutti i segnalibri",
+		"description": ""
+	},
+	"settings": {
+		"message": "Impostazioni",
+		"description": ""
+	},
+	"help": {
+		"message": "Aiuto",
+		"description": ""
+	},
+	"localCount": {
+		"message": "Numero di segnalibri locali",
+		"description": ""
+	},
+	"remoteCount": {
+		"message": "Numero di segnalibri remoti",
+		"description": ""
+	},
+	"githubToken": {
+		"message": "Token GitHub",
+		"description": ""
+	},
+	"gistID": {
+		"message": "ID Gist",
+		"description": ""
+	},
+	"gistFileName": {
+		"message": "Nome file Gist",
+		"description": ""
+	},
+	"enableNotifications": {
+		"message": "Abilita notifiche",
+		"description": ""
+	},
+	"success": {
+		"message": "Successo",
+		"description": ""
+	},
+	"failed": {
+		"message": "Fallimento",
+		"description": ""
+	},
+	"error": {
+		"message": "Errore",
+		"description": ""
+	},
+	"author": {
+		"message": "Autore",
+		"description": ""
+	},
+	"uploadBookmarksDesc": {
+		"message": "Carica tutti i segnalibri del browser locale sul server",
+		"description": ""
+	},
+	"downloadBookmarksDesc": {
+		"message": "Elimina prima i segnalibri del browser locale e poi scarica tutti i segnalibri dal server sul browser locale",
+		"description": ""
+	},
+	"syncBookmarksDesc": {
+		"message": "Unisci tutti i segnalibri del server nel browser locale e poi caricali sul server",
+		"description": ""
+	},
+	"removeAllBookmarksDesc": {
+		"message": "Rimuovi tutti i segnalibri. Fai prima un backup.",
+		"description": ""
+	},
+	"autoSyncTitle": {
+		"message": "Scheduled Auto Sync",
+		"description": ""
+	},
+	"autoSyncMissingConfig": {
+		"message": "Please fill in Token / Gist ID / File Name in settings first",
+		"description": ""
+	},
+	"autoSyncSection": {
+		"message": "Scheduled Auto Sync",
+		"description": ""
+	},
+	"autoSyncEnable": {
+		"message": "Enable Auto Sync",
+		"description": ""
+	},
+	"autoSyncEnableDesc": {
+		"message": "Sync bookmarks between local and Gist on a schedule",
+		"description": ""
+	},
+	"autoSyncInterval": {
+		"message": "Sync Interval",
+		"description": ""
+	},
+	"autoSyncDirection": {
+		"message": "Sync Direction",
+		"description": ""
+	},
+	"autoSyncDirBoth": {
+		"message": "Bidirectional (download then upload)",
+		"description": ""
+	},
+	"autoSyncDirUpload": {
+		"message": "Upload only (local → Gist)",
+		"description": ""
+	},
+	"autoSyncDirDownload": {
+		"message": "Download only (Gist → local)",
+		"description": ""
+	},
+	"autoSyncOnStartup": {
+		"message": "Sync on Browser Startup",
+		"description": ""
+	},
+	"autoSyncOnStartupDesc": {
+		"message": "Trigger a sync immediately when browser starts",
+		"description": ""
+	},
+	"autoSyncLastTime": {
+		"message": "Last Auto Sync",
+		"description": ""
+	},
+	"autoSyncRunNow": {
+		"message": "Run Now",
+		"description": ""
+	},
+	"autoSyncSave": {
+		"message": "Save",
+		"description": ""
+	},
+	"autoSyncSaved": {
+		"message": "Saved, auto sync settings applied",
+		"description": ""
+	},
+	"autoSyncSaveError": {
+		"message": "Saved, but failed to notify background",
+		"description": ""
+	},
+	"autoSyncNever": {
+		"message": "Never",
+		"description": ""
+	},
+	"lastSync": {
+		"message": "Last Sync",
+		"description": ""
+	},
+	"lastSyncNotYet": {
+		"message": "Not yet updated",
+		"description": ""
+	},
+	"lastSyncSourceAuto": {
+		"message": "Auto",
+		"description": ""
+	},
+	"lastSyncSourceManual": {
+		"message": "Manual",
+		"description": ""
+	},
+	"autoSyncInterval_15m": {
+		"message": "15 minutes",
+		"description": "Auto sync interval option: 15 minutes"
+	},
+	"autoSyncInterval_30m": {
+		"message": "30 minutes",
+		"description": "Auto sync interval option: 30 minutes"
+	},
+	"autoSyncInterval_1h": {
+		"message": "1 hour",
+		"description": "Auto sync interval option: 1 hour"
+	},
+	"autoSyncInterval_2h": {
+		"message": "2 hours",
+		"description": "Auto sync interval option: 2 hours"
+	},
+	"autoSyncInterval_6h": {
+		"message": "6 hours",
+		"description": "Auto sync interval option: 6 hours"
+	},
+	"autoSyncInterval_12h": {
+		"message": "12 hours",
+		"description": "Auto sync interval option: 12 hours"
+	},
+	"autoSyncInterval_24h": {
+		"message": "24 hours",
+		"description": "Auto sync interval option: 24 hours"
+	},
+	"autoSyncInterval_48h": {
+		"message": "48 hours",
+		"description": "Auto sync interval option: 48 hours"
+	},
+	"autoSyncInterval_72h": {
+		"message": "72 hours",
+		"description": "Auto sync interval option: 72 hours"
+	},
+	"autoSyncRunning": {
+		"message": "⏳ Syncing..."
+	},
+	"autoSyncRunSuccess": {
+		"message": "✅ Synced at "
+	},
+	"autoSyncRunDone": {
+		"message": "✅ Sync completed"
+	},
+	"autoSyncRunError": {
+		"message": "❌ Sync failed: "
+	},
+	"viewGist": {
+		"message": "Visualizza Gist"
+	},
+	"viewGistTitle": {
+		"message": "Visualizza il file dei segnalibri sincronizzato su GitHub"
+	},
+	"viewGistHint": {
+		"message": "Inserisci prima l'ID del Gist"
+	},
+	"githubTokenHelp": {
+		"message": "È richiesto un Personal Access Token (classic) con ambito 'gist'.",
+		"description": "Suggerimento mostrato sotto il campo Token GitHub"
+	},
+	"getToken": {
+		"message": "Ottieni Token",
+		"description": "Pulsante per aprire la pagina delle impostazioni del token GitHub"
+	},
+	"createNewGist": {
+		"message": "📝 Crea nuovo Gist",
+		"description": "Link per aprire gist.github.com"
+	},
+	"gistIDHelp": {
+		"message": "Incolla solo la parte ID del tuo URL Gist (es. per gist.github.com/<ID>, copia solo la parte <ID>, non l'URL completo).",
+		"description": "Suggerimento mostrato sotto il campo ID Gist"
+	},
+	"aiOrganizeSection": {
+		"message": "🤖 Organizza segnalibri con IA",
+		"description": "Options page advanced features section title"
+	},
+	"aiOrganizeBackendUrl": {
+		"message": "URL del backend IA",
+		"description": "Label for the backend service URL input in advanced features"
+	},
+	"aiOrganizeBackendUrlHelp": {
+		"message": "Predefinito http://103.11.78.250:18903. Modifica se ospiti il tuo backend.",
+		"description": "Help text shown below the backend URL input"
+	},
+	"aiOrganizeRunButton": {
+		"message": "Organizza segnalibri",
+		"description": "Button that triggers the AI organize task"
+	},
+	"aiOrganizeRunningTitle": {
+		"message": "🤖 Organizzazione IA in corso…",
+		"description": "Title of the progress bar shown in the popup during the task"
+	},
+	"aiOrganizeProgressLabel": {
+		"message": "{current} / {total} completati ({step})",
+		"description": "Progress text template; {current}/{total} done, {step} shown"
+	},
+	"aiOrganizeModalTitle": {
+		"message": "🎉 Organizzazione completata",
+		"description": "Title of the success modal shown after organizing completes"
+	},
+	"aiOrganizeModalSummary": {
+		"message": "Organizzati {count} segnalibri in {cats} categorie",
+		"description": "Summary line in the success modal; {count} bookmarks in {cats} categories"
+	},
+	"aiOrganizeModalHint": {
+		"message": "Organizzato nella cartella radice 「AI分类」 del tuo Gist. Clicca su \"Scarica segnalibri\" nella popup per sincronizzare.",
+		"description": "Hint shown in the success modal telling user to download via popup"
+	},
+	"aiOrganizeModalClose": {
+		"message": "Chiudi",
+		"description": "Close button label on the success/failure modal"
+	},
+	"aiOrganizeFailed": {
+		"message": "❌ Organizzazione fallita",
+		"description": "Title of the failure modal shown when the AI organize task fails"
+	},
+	"aiOrganizeMissingConfig": {
+		"message": "Configura prima Token / Gist ID / Nome file",
+		"description": "Error message when token/gist/file-name config is missing"
+	},
+	"aiOrganizeStartHint": {
+		"message": "✅ Started. Results window will pop up automatically when done.",
+		"description": "Toast message shown after successfully starting the AI organize task"
+	},
+	"aiOrganizeRunning": {
+		"message": "IA in corso…",
+		"description": "Label shown on the Organize button while a task is running"
+	}
 }

--- a/src/public/_locales/ja/messages.json
+++ b/src/public/_locales/ja/messages.json
@@ -1,90 +1,307 @@
 {
-    "extensionName": {
-        "message": "BookmarkHub - ブックマークを同期",
-        "description": ""
-    },
-    "extensionDescription": {
-        "message": "BookmarkHub、異なるブラウザ間でブックマークを同期",
-        "description": ""
-    },
-    "uploadBookmarks": {
-        "message": "ブックマークをアップロード",
-        "description": ""
-    },
-    "downloadBookmarks": {
-        "message": "ブックマークをダウンロード",
-        "description": ""
-    },
-    "syncBookmarks": {
-        "message": "ブックマークを同期",
-        "description": ""
-    },
-    "removeAllBookmarks": {
-        "message": "全てのブックマークを削除",
-        "description": ""
-    },
-    "settings": {
-        "message": "設定",
-        "description": ""
-    },
-    "help": {
-        "message": "ヘルプ",
-        "description": ""
-    },
-    "localCount": {
-        "message": "ローカルのブックマーク数",
-        "description": ""
-    },
-    "remoteCount": {
-        "message": "リモートのブックマーク数",
-        "description": ""
-    },
-    "githubToken": {
-        "message": "GitHub トークン",
-        "description": ""
-    },
-    "gistID": {
-        "message": "Gist ID",
-        "description": ""
-    },
-    "gistFileName": {
-        "message": "Gist ファイル名",
-        "description": ""
-    },
-    "enableNotifications": {
-        "message": "通知を有効にする",
-        "description": ""
-    },
-    "success": {
-        "message": "成功",
-        "description": ""
-    },
-    "failed": {
-        "message": "失敗",
-        "description": ""
-    },
-    "error": {
-        "message": "エラー",
-        "description": ""
-    },
-    "author": {
-        "message": "著者",
-        "description": ""
-    },
-    "uploadBookmarksDesc": {
-        "message": "ローカルブラウザの全てのブックマークをサーバーにアップロード",
-        "description": ""
-    },
-    "downloadBookmarksDesc": {
-        "message": "まずローカルブラウザのブックマークを削除し、次にサーバー上の全てのブックマークをローカルブラウザにダウンロード",
-        "description": ""
-    },
-    "syncBookmarksDesc": {
-        "message": "サーバー上の全てのブックマークをローカルブラウザにマージし、次にサーバーにアップロード",
-        "description": ""
-    },
-    "removeAllBookmarksDesc": {
-        "message": "全てのブックマークを削除します。事前にバックアップを行ってください。",
-        "description": ""
-    }
+	"extensionName": {
+		"message": "BookmarkHub - ブックマークを同期",
+		"description": ""
+	},
+	"extensionDescription": {
+		"message": "BookmarkHub、異なるブラウザ間でブックマークを同期",
+		"description": ""
+	},
+	"uploadBookmarks": {
+		"message": "ブックマークをアップロード",
+		"description": ""
+	},
+	"downloadBookmarks": {
+		"message": "ブックマークをダウンロード",
+		"description": ""
+	},
+	"syncBookmarks": {
+		"message": "ブックマークを同期",
+		"description": ""
+	},
+	"removeAllBookmarks": {
+		"message": "全てのブックマークを削除",
+		"description": ""
+	},
+	"settings": {
+		"message": "設定",
+		"description": ""
+	},
+	"help": {
+		"message": "ヘルプ",
+		"description": ""
+	},
+	"localCount": {
+		"message": "ローカルのブックマーク数",
+		"description": ""
+	},
+	"remoteCount": {
+		"message": "リモートのブックマーク数",
+		"description": ""
+	},
+	"githubToken": {
+		"message": "GitHub トークン",
+		"description": ""
+	},
+	"gistID": {
+		"message": "Gist ID",
+		"description": ""
+	},
+	"gistFileName": {
+		"message": "Gist ファイル名",
+		"description": ""
+	},
+	"enableNotifications": {
+		"message": "通知を有効にする",
+		"description": ""
+	},
+	"success": {
+		"message": "成功",
+		"description": ""
+	},
+	"failed": {
+		"message": "失敗",
+		"description": ""
+	},
+	"error": {
+		"message": "エラー",
+		"description": ""
+	},
+	"author": {
+		"message": "著者",
+		"description": ""
+	},
+	"uploadBookmarksDesc": {
+		"message": "ローカルブラウザの全てのブックマークをサーバーにアップロード",
+		"description": ""
+	},
+	"downloadBookmarksDesc": {
+		"message": "まずローカルブラウザのブックマークを削除し、次にサーバー上の全てのブックマークをローカルブラウザにダウンロード",
+		"description": ""
+	},
+	"syncBookmarksDesc": {
+		"message": "サーバー上の全てのブックマークをローカルブラウザにマージし、次にサーバーにアップロード",
+		"description": ""
+	},
+	"removeAllBookmarksDesc": {
+		"message": "全てのブックマークを削除します。事前にバックアップを行ってください。",
+		"description": ""
+	},
+	"autoSyncTitle": {
+		"message": "Scheduled Auto Sync",
+		"description": ""
+	},
+	"autoSyncMissingConfig": {
+		"message": "Please fill in Token / Gist ID / File Name in settings first",
+		"description": ""
+	},
+	"autoSyncSection": {
+		"message": "Scheduled Auto Sync",
+		"description": ""
+	},
+	"autoSyncEnable": {
+		"message": "Enable Auto Sync",
+		"description": ""
+	},
+	"autoSyncEnableDesc": {
+		"message": "Sync bookmarks between local and Gist on a schedule",
+		"description": ""
+	},
+	"autoSyncInterval": {
+		"message": "Sync Interval",
+		"description": ""
+	},
+	"autoSyncDirection": {
+		"message": "Sync Direction",
+		"description": ""
+	},
+	"autoSyncDirBoth": {
+		"message": "Bidirectional (download then upload)",
+		"description": ""
+	},
+	"autoSyncDirUpload": {
+		"message": "Upload only (local → Gist)",
+		"description": ""
+	},
+	"autoSyncDirDownload": {
+		"message": "Download only (Gist → local)",
+		"description": ""
+	},
+	"autoSyncOnStartup": {
+		"message": "Sync on Browser Startup",
+		"description": ""
+	},
+	"autoSyncOnStartupDesc": {
+		"message": "Trigger a sync immediately when browser starts",
+		"description": ""
+	},
+	"autoSyncLastTime": {
+		"message": "Last Auto Sync",
+		"description": ""
+	},
+	"autoSyncRunNow": {
+		"message": "Run Now",
+		"description": ""
+	},
+	"autoSyncSave": {
+		"message": "Save",
+		"description": ""
+	},
+	"autoSyncSaved": {
+		"message": "Saved, auto sync settings applied",
+		"description": ""
+	},
+	"autoSyncSaveError": {
+		"message": "Saved, but failed to notify background",
+		"description": ""
+	},
+	"autoSyncNever": {
+		"message": "Never",
+		"description": ""
+	},
+	"lastSync": {
+		"message": "Last Sync",
+		"description": ""
+	},
+	"lastSyncNotYet": {
+		"message": "Not yet updated",
+		"description": ""
+	},
+	"lastSyncSourceAuto": {
+		"message": "Auto",
+		"description": ""
+	},
+	"lastSyncSourceManual": {
+		"message": "Manual",
+		"description": ""
+	},
+	"autoSyncInterval_15m": {
+		"message": "15 minutes",
+		"description": "Auto sync interval option: 15 minutes"
+	},
+	"autoSyncInterval_30m": {
+		"message": "30 minutes",
+		"description": "Auto sync interval option: 30 minutes"
+	},
+	"autoSyncInterval_1h": {
+		"message": "1 hour",
+		"description": "Auto sync interval option: 1 hour"
+	},
+	"autoSyncInterval_2h": {
+		"message": "2 hours",
+		"description": "Auto sync interval option: 2 hours"
+	},
+	"autoSyncInterval_6h": {
+		"message": "6 hours",
+		"description": "Auto sync interval option: 6 hours"
+	},
+	"autoSyncInterval_12h": {
+		"message": "12 hours",
+		"description": "Auto sync interval option: 12 hours"
+	},
+	"autoSyncInterval_24h": {
+		"message": "24 hours",
+		"description": "Auto sync interval option: 24 hours"
+	},
+	"autoSyncInterval_48h": {
+		"message": "48 hours",
+		"description": "Auto sync interval option: 48 hours"
+	},
+	"autoSyncInterval_72h": {
+		"message": "72 hours",
+		"description": "Auto sync interval option: 72 hours"
+	},
+	"autoSyncRunning": {
+		"message": "⏳ Syncing..."
+	},
+	"autoSyncRunSuccess": {
+		"message": "✅ Synced at "
+	},
+	"autoSyncRunDone": {
+		"message": "✅ Sync completed"
+	},
+	"autoSyncRunError": {
+		"message": "❌ Sync failed: "
+	},
+	"viewGist": {
+		"message": "Gist を表示"
+	},
+	"viewGistTitle": {
+		"message": "GitHub で同期したブックマークファイルを表示"
+	},
+	"viewGistHint": {
+		"message": "先に Gist ID を入力してください"
+	},
+	"githubTokenHelp": {
+		"message": "gist スコープを持つ Personal Access Token (classic) が必要です。",
+		"description": "GitHub Token フィールド下に表示されるヒント"
+	},
+	"getToken": {
+		"message": "トークンを取得",
+		"description": "GitHub トークン設定ページを開くボタン"
+	},
+	"createNewGist": {
+		"message": "📝 新しい Gist を作成",
+		"description": "gist.github.com で新規 Gist を作成するリンク"
+	},
+	"gistIDHelp": {
+		"message": "Gist URL の ID 部分のみを貼り付けてください（例：gist.github.com/<ID> の <ID> のみ、完全な URL ではなく）。",
+		"description": "Gist ID フィールド下に表示されるヒント"
+	},
+	"aiOrganizeSection": {
+		"message": "🤖 AI でブックマークを整理",
+		"description": "Options page advanced features section title"
+	},
+	"aiOrganizeBackendUrl": {
+		"message": "AI 整理バックエンド URL",
+		"description": "Label for the backend service URL input in advanced features"
+	},
+	"aiOrganizeBackendUrlHelp": {
+		"message": "デフォルトは http://103.11.78.250:18903。自分でホストする場合は変更してください。",
+		"description": "Help text shown below the backend URL input"
+	},
+	"aiOrganizeRunButton": {
+		"message": "ブックマークを整理",
+		"description": "Button that triggers the AI organize task"
+	},
+	"aiOrganizeRunningTitle": {
+		"message": "🤖 AI 整理中…",
+		"description": "Title of the progress bar shown in the popup during the task"
+	},
+	"aiOrganizeProgressLabel": {
+		"message": "{current} / {total} 完了（{step}）",
+		"description": "Progress text template; {current}/{total} done, {step} shown"
+	},
+	"aiOrganizeModalTitle": {
+		"message": "🎉 整理完了",
+		"description": "Title of the success modal shown after organizing completes"
+	},
+	"aiOrganizeModalSummary": {
+		"message": "{count} 個のブックマークを {cats} カテゴリに整理しました",
+		"description": "Summary line in the success modal; {count} bookmarks in {cats} categories"
+	},
+	"aiOrganizeModalHint": {
+		"message": "Gistの「AI分类」ルートフォルダーに整理されました。ポップアップで「ブックマークをダウンロード」をクリックして同期してください。",
+		"description": "Hint shown in the success modal telling user to download via popup"
+	},
+	"aiOrganizeModalClose": {
+		"message": "閉じる",
+		"description": "Close button label on the success/failure modal"
+	},
+	"aiOrganizeFailed": {
+		"message": "❌ 整理に失敗しました",
+		"description": "Title of the failure modal shown when the AI organize task fails"
+	},
+	"aiOrganizeMissingConfig": {
+		"message": "まず Token / Gist ID / ファイル名を設定してください",
+		"description": "Error message when token/gist/file-name config is missing"
+	},
+	"aiOrganizeStartHint": {
+		"message": "✅ Started. Results window will pop up automatically when done.",
+		"description": "Toast message shown after successfully starting the AI organize task"
+	},
+	"aiOrganizeRunning": {
+		"message": "AI 整理中…",
+		"description": "Label shown on the Organize button while a task is running"
+	}
 }

--- a/src/public/_locales/ko/messages.json
+++ b/src/public/_locales/ko/messages.json
@@ -1,90 +1,307 @@
 {
-    "extensionName": {
-        "message": "BookmarkHub - 북마크 동기화",
-        "description": ""
-    },
-    "extensionDescription": {
-        "message": "BookmarkHub, 다양한 브라우저 간 북마크 동기화",
-        "description": ""
-    },
-    "uploadBookmarks": {
-        "message": "북마크 업로드",
-        "description": ""
-    },
-    "downloadBookmarks": {
-        "message": "북마크 다운로드",
-        "description": ""
-    },
-    "syncBookmarks": {
-        "message": "북마크 동기화",
-        "description": ""
-    },
-    "removeAllBookmarks": {
-        "message": "모든 북마크 삭제",
-        "description": ""
-    },
-    "settings": {
-        "message": "설정",
-        "description": ""
-    },
-    "help": {
-        "message": "도움말",
-        "description": ""
-    },
-    "localCount": {
-        "message": "로컬 북마크 수",
-        "description": ""
-    },
-    "remoteCount": {
-        "message": "원격 북마크 수",
-        "description": ""
-    },
-    "githubToken": {
-        "message": "GitHub 토큰",
-        "description": ""
-    },
-    "gistID": {
-        "message": "Gist ID",
-        "description": ""
-    },
-    "gistFileName": {
-        "message": "Gist 파일명",
-        "description": ""
-    },
-    "enableNotifications": {
-        "message": "알림 활성화",
-        "description": ""
-    },
-    "success": {
-        "message": "성공",
-        "description": ""
-    },
-    "failed": {
-        "message": "실패",
-        "description": ""
-    },
-    "error": {
-        "message": "오류",
-        "description": ""
-    },
-    "author": {
-        "message": "작성자",
-        "description": ""
-    },
-    "uploadBookmarksDesc": {
-        "message": "로컬 브라우저의 모든 북마크를 서버로 업로드",
-        "description": ""
-    },
-    "downloadBookmarksDesc": {
-        "message": "먼저 로컬 브라우저의 북마크를 삭제한 후, 서버의 모든 북마크를 로컬 브라우저로 다운로드",
-        "description": ""
-    },
-    "syncBookmarksDesc": {
-        "message": "서버의 모든 북마크를 로컬 브라우저에 병합한 후, 서버로 업로드",
-        "description": ""
-    },
-    "removeAllBookmarksDesc": {
-        "message": "모든 북마크를 삭제합니다. 사전에 백업하세요.",
-        "description": ""
-    }
+	"extensionName": {
+		"message": "BookmarkHub - 북마크 동기화",
+		"description": ""
+	},
+	"extensionDescription": {
+		"message": "BookmarkHub, 다양한 브라우저 간 북마크 동기화",
+		"description": ""
+	},
+	"uploadBookmarks": {
+		"message": "북마크 업로드",
+		"description": ""
+	},
+	"downloadBookmarks": {
+		"message": "북마크 다운로드",
+		"description": ""
+	},
+	"syncBookmarks": {
+		"message": "북마크 동기화",
+		"description": ""
+	},
+	"removeAllBookmarks": {
+		"message": "모든 북마크 삭제",
+		"description": ""
+	},
+	"settings": {
+		"message": "설정",
+		"description": ""
+	},
+	"help": {
+		"message": "도움말",
+		"description": ""
+	},
+	"localCount": {
+		"message": "로컬 북마크 수",
+		"description": ""
+	},
+	"remoteCount": {
+		"message": "원격 북마크 수",
+		"description": ""
+	},
+	"githubToken": {
+		"message": "GitHub 토큰",
+		"description": ""
+	},
+	"gistID": {
+		"message": "Gist ID",
+		"description": ""
+	},
+	"gistFileName": {
+		"message": "Gist 파일명",
+		"description": ""
+	},
+	"enableNotifications": {
+		"message": "알림 활성화",
+		"description": ""
+	},
+	"success": {
+		"message": "성공",
+		"description": ""
+	},
+	"failed": {
+		"message": "실패",
+		"description": ""
+	},
+	"error": {
+		"message": "오류",
+		"description": ""
+	},
+	"author": {
+		"message": "작성자",
+		"description": ""
+	},
+	"uploadBookmarksDesc": {
+		"message": "로컬 브라우저의 모든 북마크를 서버로 업로드",
+		"description": ""
+	},
+	"downloadBookmarksDesc": {
+		"message": "먼저 로컬 브라우저의 북마크를 삭제한 후, 서버의 모든 북마크를 로컬 브라우저로 다운로드",
+		"description": ""
+	},
+	"syncBookmarksDesc": {
+		"message": "서버의 모든 북마크를 로컬 브라우저에 병합한 후, 서버로 업로드",
+		"description": ""
+	},
+	"removeAllBookmarksDesc": {
+		"message": "모든 북마크를 삭제합니다. 사전에 백업하세요.",
+		"description": ""
+	},
+	"autoSyncTitle": {
+		"message": "Scheduled Auto Sync",
+		"description": ""
+	},
+	"autoSyncMissingConfig": {
+		"message": "Please fill in Token / Gist ID / File Name in settings first",
+		"description": ""
+	},
+	"autoSyncSection": {
+		"message": "Scheduled Auto Sync",
+		"description": ""
+	},
+	"autoSyncEnable": {
+		"message": "Enable Auto Sync",
+		"description": ""
+	},
+	"autoSyncEnableDesc": {
+		"message": "Sync bookmarks between local and Gist on a schedule",
+		"description": ""
+	},
+	"autoSyncInterval": {
+		"message": "Sync Interval",
+		"description": ""
+	},
+	"autoSyncDirection": {
+		"message": "Sync Direction",
+		"description": ""
+	},
+	"autoSyncDirBoth": {
+		"message": "Bidirectional (download then upload)",
+		"description": ""
+	},
+	"autoSyncDirUpload": {
+		"message": "Upload only (local → Gist)",
+		"description": ""
+	},
+	"autoSyncDirDownload": {
+		"message": "Download only (Gist → local)",
+		"description": ""
+	},
+	"autoSyncOnStartup": {
+		"message": "Sync on Browser Startup",
+		"description": ""
+	},
+	"autoSyncOnStartupDesc": {
+		"message": "Trigger a sync immediately when browser starts",
+		"description": ""
+	},
+	"autoSyncLastTime": {
+		"message": "Last Auto Sync",
+		"description": ""
+	},
+	"autoSyncRunNow": {
+		"message": "Run Now",
+		"description": ""
+	},
+	"autoSyncSave": {
+		"message": "Save",
+		"description": ""
+	},
+	"autoSyncSaved": {
+		"message": "Saved, auto sync settings applied",
+		"description": ""
+	},
+	"autoSyncSaveError": {
+		"message": "Saved, but failed to notify background",
+		"description": ""
+	},
+	"autoSyncNever": {
+		"message": "Never",
+		"description": ""
+	},
+	"lastSync": {
+		"message": "Last Sync",
+		"description": ""
+	},
+	"lastSyncNotYet": {
+		"message": "Not yet updated",
+		"description": ""
+	},
+	"lastSyncSourceAuto": {
+		"message": "Auto",
+		"description": ""
+	},
+	"lastSyncSourceManual": {
+		"message": "Manual",
+		"description": ""
+	},
+	"autoSyncInterval_15m": {
+		"message": "15 minutes",
+		"description": "Auto sync interval option: 15 minutes"
+	},
+	"autoSyncInterval_30m": {
+		"message": "30 minutes",
+		"description": "Auto sync interval option: 30 minutes"
+	},
+	"autoSyncInterval_1h": {
+		"message": "1 hour",
+		"description": "Auto sync interval option: 1 hour"
+	},
+	"autoSyncInterval_2h": {
+		"message": "2 hours",
+		"description": "Auto sync interval option: 2 hours"
+	},
+	"autoSyncInterval_6h": {
+		"message": "6 hours",
+		"description": "Auto sync interval option: 6 hours"
+	},
+	"autoSyncInterval_12h": {
+		"message": "12 hours",
+		"description": "Auto sync interval option: 12 hours"
+	},
+	"autoSyncInterval_24h": {
+		"message": "24 hours",
+		"description": "Auto sync interval option: 24 hours"
+	},
+	"autoSyncInterval_48h": {
+		"message": "48 hours",
+		"description": "Auto sync interval option: 48 hours"
+	},
+	"autoSyncInterval_72h": {
+		"message": "72 hours",
+		"description": "Auto sync interval option: 72 hours"
+	},
+	"autoSyncRunning": {
+		"message": "⏳ Syncing..."
+	},
+	"autoSyncRunSuccess": {
+		"message": "✅ Synced at "
+	},
+	"autoSyncRunDone": {
+		"message": "✅ Sync completed"
+	},
+	"autoSyncRunError": {
+		"message": "❌ Sync failed: "
+	},
+	"viewGist": {
+		"message": "Gist 보기"
+	},
+	"viewGistTitle": {
+		"message": "GitHub에서 동기화된 북마크 파일 보기"
+	},
+	"viewGistHint": {
+		"message": "먼저 Gist ID를 입력하세요"
+	},
+	"githubTokenHelp": {
+		"message": "'gist' 범위가 있는 Personal Access Token (classic)이 필요합니다.",
+		"description": "GitHub Token 필드 아래에 표시되는 도움말"
+	},
+	"getToken": {
+		"message": "토큰 받기",
+		"description": "GitHub 토큰 설정 페이지를 여는 버튼"
+	},
+	"createNewGist": {
+		"message": "📝 새 Gist 만들기",
+		"description": "gist.github.com에서 새 Gist를 만드는 링크"
+	},
+	"gistIDHelp": {
+		"message": "Gist URL의 ID 부분만 붙여넣으세요(예: gist.github.com/<ID>에서 <ID> 부분만, 전체 URL 아님).",
+		"description": "Gist ID 필드 아래에 표시되는 도움말"
+	},
+	"aiOrganizeSection": {
+		"message": "🤖 AI 북마크 정리",
+		"description": "Options page advanced features section title"
+	},
+	"aiOrganizeBackendUrl": {
+		"message": "AI 정리 백엔드 URL",
+		"description": "Label for the backend service URL input in advanced features"
+	},
+	"aiOrganizeBackendUrlHelp": {
+		"message": "기본값은 http://103.11.78.250:18903입니다. 자체 호스팅 시 변경하세요.",
+		"description": "Help text shown below the backend URL input"
+	},
+	"aiOrganizeRunButton": {
+		"message": "북마크 정리",
+		"description": "Button that triggers the AI organize task"
+	},
+	"aiOrganizeRunningTitle": {
+		"message": "🤖 AI 정리 중…",
+		"description": "Title of the progress bar shown in the popup during the task"
+	},
+	"aiOrganizeProgressLabel": {
+		"message": "{current} / {total} 완료 ({step})",
+		"description": "Progress text template; {current}/{total} done, {step} shown"
+	},
+	"aiOrganizeModalTitle": {
+		"message": "🎉 정리 완료",
+		"description": "Title of the success modal shown after organizing completes"
+	},
+	"aiOrganizeModalSummary": {
+		"message": "{count}개 북마크를 {cats}개 카테고리로 정리했습니다",
+		"description": "Summary line in the success modal; {count} bookmarks in {cats} categories"
+	},
+	"aiOrganizeModalHint": {
+		"message": "Gist의 「AI分类」 루트 폴더에 정리되었습니다. 팝업에서 \"북마크 다운로드\"를 클릭하여 동기화하세요.",
+		"description": "Hint shown in the success modal telling user to download via popup"
+	},
+	"aiOrganizeModalClose": {
+		"message": "닫기",
+		"description": "Close button label on the success/failure modal"
+	},
+	"aiOrganizeFailed": {
+		"message": "❌ 정리 실패",
+		"description": "Title of the failure modal shown when the AI organize task fails"
+	},
+	"aiOrganizeMissingConfig": {
+		"message": "먼저 Token / Gist ID / 파일 이름을 설정하세요",
+		"description": "Error message when token/gist/file-name config is missing"
+	},
+	"aiOrganizeStartHint": {
+		"message": "✅ Started. Results window will pop up automatically when done.",
+		"description": "Toast message shown after successfully starting the AI organize task"
+	},
+	"aiOrganizeRunning": {
+		"message": "AI 정리 중…",
+		"description": "Label shown on the Organize button while a task is running"
+	}
 }

--- a/src/public/_locales/pt/messages.json
+++ b/src/public/_locales/pt/messages.json
@@ -1,90 +1,307 @@
 {
-    "extensionName": {
-        "message": "BookmarkHub - Sincronização de favoritos",
-        "description": ""
-    },
-    "extensionDescription": {
-        "message": "BookmarkHub, sincronização de favoritos entre diferentes navegadores",
-        "description": ""
-    },
-    "uploadBookmarks": {
-        "message": "Enviar favoritos",
-        "description": ""
-    },
-    "downloadBookmarks": {
-        "message": "Baixar favoritos",
-        "description": ""
-    },
-    "syncBookmarks": {
-        "message": "Sincronizar favoritos",
-        "description": ""
-    },
-    "removeAllBookmarks": {
-        "message": "Remover todos os favoritos",
-        "description": ""
-    },
-    "settings": {
-        "message": "Configurações",
-        "description": ""
-    },
-    "help": {
-        "message": "Ajuda",
-        "description": ""
-    },
-    "localCount": {
-        "message": "Quantidade de favoritos locais",
-        "description": ""
-    },
-    "remoteCount": {
-        "message": "Quantidade de favoritos remotos",
-        "description": ""
-    },
-    "githubToken": {
-        "message": "Token do GitHub",
-        "description": ""
-    },
-    "gistID": {
-        "message": "ID do Gist",
-        "description": ""
-    },
-    "gistFileName": {
-        "message": "Nome do arquivo do Gist",
-        "description": ""
-    },
-    "enableNotifications": {
-        "message": "Ativar notificações",
-        "description": ""
-    },
-    "success": {
-        "message": "Sucesso",
-        "description": ""
-    },
-    "failed": {
-        "message": "Falha",
-        "description": ""
-    },
-    "error": {
-        "message": "Erro",
-        "description": ""
-    },
-    "author": {
-        "message": "Autor",
-        "description": ""
-    },
-    "uploadBookmarksDesc": {
-        "message": "Enviar todos os favoritos do navegador local para o servidor",
-        "description": ""
-    },
-    "downloadBookmarksDesc": {
-        "message": "Remover primeiro os favoritos do navegador local e depois baixar todos os favoritos do servidor para o navegador local",
-        "description": ""
-    },
-    "syncBookmarksDesc": {
-        "message": "Combinar todos os favoritos do servidor no navegador local e depois enviar para o servidor",
-        "description": ""
-    },
-    "removeAllBookmarksDesc": {
-        "message": "Remover todos os favoritos. Por favor, faça um backup primeiro.",
-        "description": ""
-    }
+	"extensionName": {
+		"message": "BookmarkHub - Sincronização de favoritos",
+		"description": ""
+	},
+	"extensionDescription": {
+		"message": "BookmarkHub, sincronização de favoritos entre diferentes navegadores",
+		"description": ""
+	},
+	"uploadBookmarks": {
+		"message": "Enviar favoritos",
+		"description": ""
+	},
+	"downloadBookmarks": {
+		"message": "Baixar favoritos",
+		"description": ""
+	},
+	"syncBookmarks": {
+		"message": "Sincronizar favoritos",
+		"description": ""
+	},
+	"removeAllBookmarks": {
+		"message": "Remover todos os favoritos",
+		"description": ""
+	},
+	"settings": {
+		"message": "Configurações",
+		"description": ""
+	},
+	"help": {
+		"message": "Ajuda",
+		"description": ""
+	},
+	"localCount": {
+		"message": "Quantidade de favoritos locais",
+		"description": ""
+	},
+	"remoteCount": {
+		"message": "Quantidade de favoritos remotos",
+		"description": ""
+	},
+	"githubToken": {
+		"message": "Token do GitHub",
+		"description": ""
+	},
+	"gistID": {
+		"message": "ID do Gist",
+		"description": ""
+	},
+	"gistFileName": {
+		"message": "Nome do arquivo do Gist",
+		"description": ""
+	},
+	"enableNotifications": {
+		"message": "Ativar notificações",
+		"description": ""
+	},
+	"success": {
+		"message": "Sucesso",
+		"description": ""
+	},
+	"failed": {
+		"message": "Falha",
+		"description": ""
+	},
+	"error": {
+		"message": "Erro",
+		"description": ""
+	},
+	"author": {
+		"message": "Autor",
+		"description": ""
+	},
+	"uploadBookmarksDesc": {
+		"message": "Enviar todos os favoritos do navegador local para o servidor",
+		"description": ""
+	},
+	"downloadBookmarksDesc": {
+		"message": "Remover primeiro os favoritos do navegador local e depois baixar todos os favoritos do servidor para o navegador local",
+		"description": ""
+	},
+	"syncBookmarksDesc": {
+		"message": "Combinar todos os favoritos do servidor no navegador local e depois enviar para o servidor",
+		"description": ""
+	},
+	"removeAllBookmarksDesc": {
+		"message": "Remover todos os favoritos. Por favor, faça um backup primeiro.",
+		"description": ""
+	},
+	"autoSyncTitle": {
+		"message": "Scheduled Auto Sync",
+		"description": ""
+	},
+	"autoSyncMissingConfig": {
+		"message": "Please fill in Token / Gist ID / File Name in settings first",
+		"description": ""
+	},
+	"autoSyncSection": {
+		"message": "Scheduled Auto Sync",
+		"description": ""
+	},
+	"autoSyncEnable": {
+		"message": "Enable Auto Sync",
+		"description": ""
+	},
+	"autoSyncEnableDesc": {
+		"message": "Sync bookmarks between local and Gist on a schedule",
+		"description": ""
+	},
+	"autoSyncInterval": {
+		"message": "Sync Interval",
+		"description": ""
+	},
+	"autoSyncDirection": {
+		"message": "Sync Direction",
+		"description": ""
+	},
+	"autoSyncDirBoth": {
+		"message": "Bidirectional (download then upload)",
+		"description": ""
+	},
+	"autoSyncDirUpload": {
+		"message": "Upload only (local → Gist)",
+		"description": ""
+	},
+	"autoSyncDirDownload": {
+		"message": "Download only (Gist → local)",
+		"description": ""
+	},
+	"autoSyncOnStartup": {
+		"message": "Sync on Browser Startup",
+		"description": ""
+	},
+	"autoSyncOnStartupDesc": {
+		"message": "Trigger a sync immediately when browser starts",
+		"description": ""
+	},
+	"autoSyncLastTime": {
+		"message": "Last Auto Sync",
+		"description": ""
+	},
+	"autoSyncRunNow": {
+		"message": "Run Now",
+		"description": ""
+	},
+	"autoSyncSave": {
+		"message": "Save",
+		"description": ""
+	},
+	"autoSyncSaved": {
+		"message": "Saved, auto sync settings applied",
+		"description": ""
+	},
+	"autoSyncSaveError": {
+		"message": "Saved, but failed to notify background",
+		"description": ""
+	},
+	"autoSyncNever": {
+		"message": "Never",
+		"description": ""
+	},
+	"lastSync": {
+		"message": "Last Sync",
+		"description": ""
+	},
+	"lastSyncNotYet": {
+		"message": "Not yet updated",
+		"description": ""
+	},
+	"lastSyncSourceAuto": {
+		"message": "Auto",
+		"description": ""
+	},
+	"lastSyncSourceManual": {
+		"message": "Manual",
+		"description": ""
+	},
+	"autoSyncInterval_15m": {
+		"message": "15 minutes",
+		"description": "Auto sync interval option: 15 minutes"
+	},
+	"autoSyncInterval_30m": {
+		"message": "30 minutes",
+		"description": "Auto sync interval option: 30 minutes"
+	},
+	"autoSyncInterval_1h": {
+		"message": "1 hour",
+		"description": "Auto sync interval option: 1 hour"
+	},
+	"autoSyncInterval_2h": {
+		"message": "2 hours",
+		"description": "Auto sync interval option: 2 hours"
+	},
+	"autoSyncInterval_6h": {
+		"message": "6 hours",
+		"description": "Auto sync interval option: 6 hours"
+	},
+	"autoSyncInterval_12h": {
+		"message": "12 hours",
+		"description": "Auto sync interval option: 12 hours"
+	},
+	"autoSyncInterval_24h": {
+		"message": "24 hours",
+		"description": "Auto sync interval option: 24 hours"
+	},
+	"autoSyncInterval_48h": {
+		"message": "48 hours",
+		"description": "Auto sync interval option: 48 hours"
+	},
+	"autoSyncInterval_72h": {
+		"message": "72 hours",
+		"description": "Auto sync interval option: 72 hours"
+	},
+	"autoSyncRunning": {
+		"message": "⏳ Syncing..."
+	},
+	"autoSyncRunSuccess": {
+		"message": "✅ Synced at "
+	},
+	"autoSyncRunDone": {
+		"message": "✅ Sync completed"
+	},
+	"autoSyncRunError": {
+		"message": "❌ Sync failed: "
+	},
+	"viewGist": {
+		"message": "Ver Gist"
+	},
+	"viewGistTitle": {
+		"message": "Ver o ficheiro de marcadores sincronizado no GitHub"
+	},
+	"viewGistHint": {
+		"message": "Insere primeiro o ID do Gist"
+	},
+	"githubTokenHelp": {
+		"message": "É necessário um Personal Access Token (classic) com o escopo 'gist'.",
+		"description": "Dica mostrada abaixo do campo Token do GitHub"
+	},
+	"getToken": {
+		"message": "Obter Token",
+		"description": "Botão para abrir a página de configurações de token do GitHub"
+	},
+	"createNewGist": {
+		"message": "📝 Criar novo Gist",
+		"description": "Link para criar um novo Gist em gist.github.com"
+	},
+	"gistIDHelp": {
+		"message": "Cole apenas a parte do ID da URL do Gist (por exemplo, para gist.github.com/<ID>, copie apenas a parte <ID>, não a URL completa).",
+		"description": "Dica mostrada abaixo do campo ID do Gist"
+	},
+	"aiOrganizeSection": {
+		"message": "🤖 Organizar favoritos com IA",
+		"description": "Options page advanced features section title"
+	},
+	"aiOrganizeBackendUrl": {
+		"message": "URL do backend de IA",
+		"description": "Label for the backend service URL input in advanced features"
+	},
+	"aiOrganizeBackendUrlHelp": {
+		"message": "Padrão http://103.11.78.250:18903. Altere se hospedar seu próprio backend.",
+		"description": "Help text shown below the backend URL input"
+	},
+	"aiOrganizeRunButton": {
+		"message": "Organizar favoritos",
+		"description": "Button that triggers the AI organize task"
+	},
+	"aiOrganizeRunningTitle": {
+		"message": "🤖 Organizando com IA…",
+		"description": "Title of the progress bar shown in the popup during the task"
+	},
+	"aiOrganizeProgressLabel": {
+		"message": "{current} / {total} concluídos ({step})",
+		"description": "Progress text template; {current}/{total} done, {step} shown"
+	},
+	"aiOrganizeModalTitle": {
+		"message": "🎉 Organização concluída",
+		"description": "Title of the success modal shown after organizing completes"
+	},
+	"aiOrganizeModalSummary": {
+		"message": "{count} favoritos organizados em {cats} categorias",
+		"description": "Summary line in the success modal; {count} bookmarks in {cats} categories"
+	},
+	"aiOrganizeModalHint": {
+		"message": "Organizado na pasta raiz 「AI分类」 do seu Gist. Clique em \"Baixar marcadores\" no popup para sincronizar.",
+		"description": "Hint shown in the success modal telling user to download via popup"
+	},
+	"aiOrganizeModalClose": {
+		"message": "Fechar",
+		"description": "Close button label on the success/failure modal"
+	},
+	"aiOrganizeFailed": {
+		"message": "❌ Falha ao organizar",
+		"description": "Title of the failure modal shown when the AI organize task fails"
+	},
+	"aiOrganizeMissingConfig": {
+		"message": "Configure primeiro Token / ID do Gist / Nome do arquivo",
+		"description": "Error message when token/gist/file-name config is missing"
+	},
+	"aiOrganizeStartHint": {
+		"message": "✅ Started. Results window will pop up automatically when done.",
+		"description": "Toast message shown after successfully starting the AI organize task"
+	},
+	"aiOrganizeRunning": {
+		"message": "IA organizando…",
+		"description": "Label shown on the Organize button while a task is running"
+	}
 }

--- a/src/public/_locales/ru/messages.json
+++ b/src/public/_locales/ru/messages.json
@@ -1,90 +1,307 @@
-﻿{
-    "extensionName": {
-        "message": "BookmarkHub - синхронизация закладок ",
-        "description": ""
-    },
-    "extensionDescription": {
-        "message": "BookmarkHub, синхронизация закладок между разными браузерами",
-        "description": ""
-    },
-    "uploadBookmarks": {
-        "message": "Выгрузить закладки",
-        "description": ""
-    },
-    "downloadBookmarks": {
-        "message": "Скачать закладки",
-        "description": ""
-    },
-    "syncBookmarks": {
-        "message": "Синхронизировать закладки",
-        "description": ""
-    },
-    "removeAllBookmarks": {
-        "message": "Удалить все закладки",
-        "description": ""
-    },
-    "settings": {
-        "message": "Настройки",
-        "description": ""
-    },
-    "help": {
-        "message": "Помощь",
-        "description": ""
-    },
-    "localCount": {
-        "message": "Количество локальных закладок",
-        "description": ""
-    },
-    "remoteCount": {
-        "message": "Количество закладок на сервере",
-        "description": ""
-    },
-    "githubToken": {
-        "message": "Github Token",
-        "description": ""
-    },
-    "gistID": {
-        "message": "Gist ID",
-        "description": ""
-    },
-    "gistFileName": {
-        "message": "Имя файла Gist",
-        "description": ""
-    },
-    "enableNotifications": {
-        "message": "Включить уведомления",
-        "description": ""
-    },
-    "success": {
-        "message": "Выполнено",
-        "description": ""
-    },
-    "failed": {
-        "message": "Сбой",
-        "description": ""
-    },
-    "error": {
-        "message": "Ошибка",
-        "description": ""
-    },
-    "author": {
-        "message": "Разработчик",
-        "description": ""
-    },
-    "uploadBookmarksDesc": {
-        "message": "Выгрузить все закладки из браузера на сервер",
-        "description": ""
-    },
-    "downloadBookmarksDesc": {
-        "message": "Сначала закладки в браузере очищаются, затем скачиваются с сервера",
-        "description": ""
-    },
-    "syncBookmarksDesc": {
-        "message": "Объединить закладки на сервере и браузере, а затем выгрузить их на сервер",
-        "description": ""
-    },
-    "removeAllBookmarksDesc": {
-        "message": "Удалить все закладки, пожалуйста сделайте резервную копию",
-        "description": ""
-    }
+{
+	"extensionName": {
+		"message": "BookmarkHub - синхронизация закладок ",
+		"description": ""
+	},
+	"extensionDescription": {
+		"message": "BookmarkHub, синхронизация закладок между разными браузерами",
+		"description": ""
+	},
+	"uploadBookmarks": {
+		"message": "Выгрузить закладки",
+		"description": ""
+	},
+	"downloadBookmarks": {
+		"message": "Скачать закладки",
+		"description": ""
+	},
+	"syncBookmarks": {
+		"message": "Синхронизировать закладки",
+		"description": ""
+	},
+	"removeAllBookmarks": {
+		"message": "Удалить все закладки",
+		"description": ""
+	},
+	"settings": {
+		"message": "Настройки",
+		"description": ""
+	},
+	"help": {
+		"message": "Помощь",
+		"description": ""
+	},
+	"localCount": {
+		"message": "Количество локальных закладок",
+		"description": ""
+	},
+	"remoteCount": {
+		"message": "Количество закладок на сервере",
+		"description": ""
+	},
+	"githubToken": {
+		"message": "Github Token",
+		"description": ""
+	},
+	"gistID": {
+		"message": "Gist ID",
+		"description": ""
+	},
+	"gistFileName": {
+		"message": "Имя файла Gist",
+		"description": ""
+	},
+	"enableNotifications": {
+		"message": "Включить уведомления",
+		"description": ""
+	},
+	"success": {
+		"message": "Выполнено",
+		"description": ""
+	},
+	"failed": {
+		"message": "Сбой",
+		"description": ""
+	},
+	"error": {
+		"message": "Ошибка",
+		"description": ""
+	},
+	"author": {
+		"message": "Разработчик",
+		"description": ""
+	},
+	"uploadBookmarksDesc": {
+		"message": "Выгрузить все закладки из браузера на сервер",
+		"description": ""
+	},
+	"downloadBookmarksDesc": {
+		"message": "Сначала закладки в браузере очищаются, затем скачиваются с сервера",
+		"description": ""
+	},
+	"syncBookmarksDesc": {
+		"message": "Объединить закладки на сервере и браузере, а затем выгрузить их на сервер",
+		"description": ""
+	},
+	"removeAllBookmarksDesc": {
+		"message": "Удалить все закладки, пожалуйста сделайте резервную копию",
+		"description": ""
+	},
+	"autoSyncTitle": {
+		"message": "Scheduled Auto Sync",
+		"description": ""
+	},
+	"autoSyncMissingConfig": {
+		"message": "Please fill in Token / Gist ID / File Name in settings first",
+		"description": ""
+	},
+	"autoSyncSection": {
+		"message": "Scheduled Auto Sync",
+		"description": ""
+	},
+	"autoSyncEnable": {
+		"message": "Enable Auto Sync",
+		"description": ""
+	},
+	"autoSyncEnableDesc": {
+		"message": "Sync bookmarks between local and Gist on a schedule",
+		"description": ""
+	},
+	"autoSyncInterval": {
+		"message": "Sync Interval",
+		"description": ""
+	},
+	"autoSyncDirection": {
+		"message": "Sync Direction",
+		"description": ""
+	},
+	"autoSyncDirBoth": {
+		"message": "Bidirectional (download then upload)",
+		"description": ""
+	},
+	"autoSyncDirUpload": {
+		"message": "Upload only (local → Gist)",
+		"description": ""
+	},
+	"autoSyncDirDownload": {
+		"message": "Download only (Gist → local)",
+		"description": ""
+	},
+	"autoSyncOnStartup": {
+		"message": "Sync on Browser Startup",
+		"description": ""
+	},
+	"autoSyncOnStartupDesc": {
+		"message": "Trigger a sync immediately when browser starts",
+		"description": ""
+	},
+	"autoSyncLastTime": {
+		"message": "Last Auto Sync",
+		"description": ""
+	},
+	"autoSyncRunNow": {
+		"message": "Run Now",
+		"description": ""
+	},
+	"autoSyncSave": {
+		"message": "Save",
+		"description": ""
+	},
+	"autoSyncSaved": {
+		"message": "Saved, auto sync settings applied",
+		"description": ""
+	},
+	"autoSyncSaveError": {
+		"message": "Saved, but failed to notify background",
+		"description": ""
+	},
+	"autoSyncNever": {
+		"message": "Never",
+		"description": ""
+	},
+	"lastSync": {
+		"message": "Last Sync",
+		"description": ""
+	},
+	"lastSyncNotYet": {
+		"message": "Not yet updated",
+		"description": ""
+	},
+	"lastSyncSourceAuto": {
+		"message": "Auto",
+		"description": ""
+	},
+	"lastSyncSourceManual": {
+		"message": "Manual",
+		"description": ""
+	},
+	"autoSyncInterval_15m": {
+		"message": "15 minutes",
+		"description": "Auto sync interval option: 15 minutes"
+	},
+	"autoSyncInterval_30m": {
+		"message": "30 minutes",
+		"description": "Auto sync interval option: 30 minutes"
+	},
+	"autoSyncInterval_1h": {
+		"message": "1 hour",
+		"description": "Auto sync interval option: 1 hour"
+	},
+	"autoSyncInterval_2h": {
+		"message": "2 hours",
+		"description": "Auto sync interval option: 2 hours"
+	},
+	"autoSyncInterval_6h": {
+		"message": "6 hours",
+		"description": "Auto sync interval option: 6 hours"
+	},
+	"autoSyncInterval_12h": {
+		"message": "12 hours",
+		"description": "Auto sync interval option: 12 hours"
+	},
+	"autoSyncInterval_24h": {
+		"message": "24 hours",
+		"description": "Auto sync interval option: 24 hours"
+	},
+	"autoSyncInterval_48h": {
+		"message": "48 hours",
+		"description": "Auto sync interval option: 48 hours"
+	},
+	"autoSyncInterval_72h": {
+		"message": "72 hours",
+		"description": "Auto sync interval option: 72 hours"
+	},
+	"autoSyncRunning": {
+		"message": "⏳ Syncing..."
+	},
+	"autoSyncRunSuccess": {
+		"message": "✅ Synced at "
+	},
+	"autoSyncRunDone": {
+		"message": "✅ Sync completed"
+	},
+	"autoSyncRunError": {
+		"message": "❌ Sync failed: "
+	},
+	"viewGist": {
+		"message": "Открыть Gist"
+	},
+	"viewGistTitle": {
+		"message": "Посмотреть файл синхронизированных закладок на GitHub"
+	},
+	"viewGistHint": {
+		"message": "Сначала укажите ID Gist"
+	},
+	"githubTokenHelp": {
+		"message": "Требуется Personal Access Token (classic) с областью 'gist'.",
+		"description": "Подсказка под полем GitHub Token"
+	},
+	"getToken": {
+		"message": "Получить Token",
+		"description": "Кнопка открытия страницы настроек токена GitHub"
+	},
+	"createNewGist": {
+		"message": "📝 Создать новый Gist",
+		"description": "Ссылка для создания нового Gist на gist.github.com"
+	},
+	"gistIDHelp": {
+		"message": "Вставьте только часть ID из URL вашего Gist (например, для gist.github.com/<ID> скопируйте только часть <ID>, а не полный URL).",
+		"description": "Подсказка под полем Gist ID"
+	},
+	"aiOrganizeSection": {
+		"message": "🤖 ИИ-организация закладок",
+		"description": "Options page advanced features section title"
+	},
+	"aiOrganizeBackendUrl": {
+		"message": "URL бэкенда ИИ",
+		"description": "Label for the backend service URL input in advanced features"
+	},
+	"aiOrganizeBackendUrlHelp": {
+		"message": "По умолчанию http://103.11.78.250:18903. Измените, если используете свой бэкенд.",
+		"description": "Help text shown below the backend URL input"
+	},
+	"aiOrganizeRunButton": {
+		"message": "Организовать закладки",
+		"description": "Button that triggers the AI organize task"
+	},
+	"aiOrganizeRunningTitle": {
+		"message": "🤖 ИИ-организация…",
+		"description": "Title of the progress bar shown in the popup during the task"
+	},
+	"aiOrganizeProgressLabel": {
+		"message": "{current} / {total} готово ({step})",
+		"description": "Progress text template; {current}/{total} done, {step} shown"
+	},
+	"aiOrganizeModalTitle": {
+		"message": "🎉 Организация завершена",
+		"description": "Title of the success modal shown after organizing completes"
+	},
+	"aiOrganizeModalSummary": {
+		"message": "Упорядочено {count} закладок по {cats} категориям",
+		"description": "Summary line in the success modal; {count} bookmarks in {cats} categories"
+	},
+	"aiOrganizeModalHint": {
+		"message": "Упорядочено в корневой папке 「AI分类」 вашего Gist. Нажмите «Загрузить закладки» во всплывающем окне для синхронизации.",
+		"description": "Hint shown in the success modal telling user to download via popup"
+	},
+	"aiOrganizeModalClose": {
+		"message": "Закрыть",
+		"description": "Close button label on the success/failure modal"
+	},
+	"aiOrganizeFailed": {
+		"message": "❌ Ошибка организации",
+		"description": "Title of the failure modal shown when the AI organize task fails"
+	},
+	"aiOrganizeMissingConfig": {
+		"message": "Сначала укажите Token / Gist ID / имя файла",
+		"description": "Error message when token/gist/file-name config is missing"
+	},
+	"aiOrganizeStartHint": {
+		"message": "✅ Started. Results window will pop up automatically when done.",
+		"description": "Toast message shown after successfully starting the AI organize task"
+	},
+	"aiOrganizeRunning": {
+		"message": "ИИ сортирует…",
+		"description": "Label shown on the Organize button while a task is running"
+	}
 }

--- a/src/public/_locales/zh_CN/messages.json
+++ b/src/public/_locales/zh_CN/messages.json
@@ -1,90 +1,307 @@
 {
-    "extensionName": {
-        "message": "BookmarkHub - 书签同步",
-        "description": ""
-    },
-    "extensionDescription": {
-        "message": "BookmarkHub，在不同浏览器之间同步你的书签",
-        "description": ""
-    },
-    "uploadBookmarks": {
-        "message": "上传书签",
-        "description": "把本地浏览器的书签全部上传到服务器中"
-    },
-    "downloadBookmarks": {
-        "message": "下载书签",
-        "description": "先清空本地浏览器中的书签，然后再把服务器上的书签全部下载到本地浏览器中"
-    },
-    "syncBookmarks": {
-        "message": "同步书签",
-        "description": "把服务器上的书签全部合并到本地浏览器中，然后再上传到服务器"
-    },
-    "removeAllBookmarks": {
-        "message": "清空本地书签",
-        "description": ""
-    },
-    "settings": {
-        "message": "设置",
-        "description": ""
-    },
-    "help": {
-        "message": "帮助",
-        "description": ""
-    },
-    "localCount": {
-        "message": "本地书签数量",
-        "description": ""
-    },
-    "remoteCount": {
-        "message": "远程书签数量",
-        "description": ""
-    },
-    "githubToken": {
-        "message": "Github Token",
-        "description": ""
-    },
-    "gistID": {
-        "message": "Gist ID",
-        "description": ""
-    },
-    "gistFileName": {
-        "message": "Gist文件名",
-        "description": ""
-    },
-    "enableNotifications": {
-        "message": "使用消息通知",
-        "description": ""
-    },
-    "success": {
-        "message": "成功",
-        "description": ""
-    },
-    "failed": {
-        "message": "失败",
-        "description": ""
-    },
-    "error": {
-        "message": "错误",
-        "description": ""
-    },
-    "author": {
-        "message": "开发者",
-        "description": ""
-    },
-    "uploadBookmarksDesc": {
-        "message": "把本地浏览器的书签全部上传到服务器中",
-        "description": ""
-    },
-    "downloadBookmarksDesc": {
-        "message": "先清空本地浏览器中的书签，然后再把服务器上的书签全部下载到本地浏览器中",
-        "description": ""
-    },
-    "syncBookmarksDesc": {
-        "message": "把服务器上的书签全部合并到本地浏览器中，然后再上传到服务器",
-        "description": ""
-    },
-    "removeAllBookmarksDesc": {
-        "message": "清空本地浏览器书签，请先做好备份",
-        "description": ""
-    }
+	"extensionName": {
+		"message": "BookmarkHub - 书签同步",
+		"description": ""
+	},
+	"extensionDescription": {
+		"message": "BookmarkHub，在不同浏览器之间同步你的书签",
+		"description": ""
+	},
+	"uploadBookmarks": {
+		"message": "上传书签",
+		"description": "把本地浏览器的书签全部上传到服务器中"
+	},
+	"downloadBookmarks": {
+		"message": "下载书签",
+		"description": "先清空本地浏览器中的书签，然后再把服务器上的书签全部下载到本地浏览器中"
+	},
+	"syncBookmarks": {
+		"message": "同步书签",
+		"description": "把服务器上的书签全部合并到本地浏览器中，然后再上传到服务器"
+	},
+	"removeAllBookmarks": {
+		"message": "清空本地书签",
+		"description": ""
+	},
+	"settings": {
+		"message": "设置",
+		"description": ""
+	},
+	"help": {
+		"message": "帮助",
+		"description": ""
+	},
+	"localCount": {
+		"message": "本地书签数量",
+		"description": ""
+	},
+	"remoteCount": {
+		"message": "远程书签数量",
+		"description": ""
+	},
+	"githubToken": {
+		"message": "Github Token",
+		"description": ""
+	},
+	"gistID": {
+		"message": "Gist ID",
+		"description": ""
+	},
+	"gistFileName": {
+		"message": "Gist文件名",
+		"description": ""
+	},
+	"enableNotifications": {
+		"message": "使用消息通知",
+		"description": ""
+	},
+	"success": {
+		"message": "成功",
+		"description": ""
+	},
+	"failed": {
+		"message": "失败",
+		"description": ""
+	},
+	"error": {
+		"message": "错误",
+		"description": ""
+	},
+	"author": {
+		"message": "开发者",
+		"description": ""
+	},
+	"uploadBookmarksDesc": {
+		"message": "把本地浏览器的书签全部上传到服务器中",
+		"description": ""
+	},
+	"downloadBookmarksDesc": {
+		"message": "先清空本地浏览器中的书签，然后再把服务器上的书签全部下载到本地浏览器中",
+		"description": ""
+	},
+	"syncBookmarksDesc": {
+		"message": "把服务器上的书签全部合并到本地浏览器中，然后再上传到服务器",
+		"description": ""
+	},
+	"removeAllBookmarksDesc": {
+		"message": "清空本地浏览器书签，请先做好备份",
+		"description": ""
+	},
+	"autoSyncTitle": {
+		"message": "定时自动同步",
+		"description": ""
+	},
+	"autoSyncMissingConfig": {
+		"message": "请先在设置中填写 Token / Gist ID / 文件名",
+		"description": ""
+	},
+	"autoSyncSection": {
+		"message": "定时自动同步",
+		"description": ""
+	},
+	"autoSyncEnable": {
+		"message": "启用自动同步",
+		"description": ""
+	},
+	"autoSyncEnableDesc": {
+		"message": "按设定周期自动在本地与 Gist 间同步书签",
+		"description": ""
+	},
+	"autoSyncInterval": {
+		"message": "同步周期",
+		"description": ""
+	},
+	"autoSyncDirection": {
+		"message": "同步方向",
+		"description": ""
+	},
+	"autoSyncDirBoth": {
+		"message": "双向同步（先下载再上传）",
+		"description": ""
+	},
+	"autoSyncDirUpload": {
+		"message": "仅上传（本地 → Gist）",
+		"description": ""
+	},
+	"autoSyncDirDownload": {
+		"message": "仅下载（Gist → 本地）",
+		"description": ""
+	},
+	"autoSyncOnStartup": {
+		"message": "浏览器启动时同步",
+		"description": ""
+	},
+	"autoSyncOnStartupDesc": {
+		"message": "浏览器启动后立即触发一次同步",
+		"description": ""
+	},
+	"autoSyncLastTime": {
+		"message": "上次自动同步",
+		"description": ""
+	},
+	"autoSyncRunNow": {
+		"message": "立即同步",
+		"description": ""
+	},
+	"autoSyncSave": {
+		"message": "保存设置",
+		"description": ""
+	},
+	"autoSyncSaved": {
+		"message": "已保存，自动同步已生效",
+		"description": ""
+	},
+	"autoSyncSaveError": {
+		"message": "已保存，但通知后台失败",
+		"description": ""
+	},
+	"autoSyncNever": {
+		"message": "从未同步",
+		"description": ""
+	},
+	"lastSync": {
+		"message": "上次同步",
+		"description": "弹框同步时间行的标签，例：'上次同步: 2026-06-22 06:45'"
+	},
+	"lastSyncNotYet": {
+		"message": "还未更新",
+		"description": "从未同步过时的占位文案，红色斜体显示"
+	},
+	"lastSyncSourceAuto": {
+		"message": "自动",
+		"description": "触发源 01：定时自动同步的徽标"
+	},
+	"lastSyncSourceManual": {
+		"message": "手动",
+		"description": "触发源 02：手动点击上传/下载的徽标"
+	},
+	"autoSyncInterval_15m": {
+		"message": "15 分钟",
+		"description": "Auto sync interval option: 15 分钟"
+	},
+	"autoSyncInterval_30m": {
+		"message": "30 分钟",
+		"description": "Auto sync interval option: 30 分钟"
+	},
+	"autoSyncInterval_1h": {
+		"message": "1 小时",
+		"description": "Auto sync interval option: 1 小时"
+	},
+	"autoSyncInterval_2h": {
+		"message": "2 小时",
+		"description": "Auto sync interval option: 2 小时"
+	},
+	"autoSyncInterval_6h": {
+		"message": "6 小时",
+		"description": "Auto sync interval option: 6 小时"
+	},
+	"autoSyncInterval_12h": {
+		"message": "12 小时",
+		"description": "Auto sync interval option: 12 小时"
+	},
+	"autoSyncInterval_24h": {
+		"message": "24 小时",
+		"description": "Auto sync interval option: 24 小时"
+	},
+	"autoSyncInterval_48h": {
+		"message": "48 小时",
+		"description": "Auto sync interval option: 48 小时"
+	},
+	"autoSyncInterval_72h": {
+		"message": "72 小时",
+		"description": "Auto sync interval option: 72 小时"
+	},
+	"autoSyncRunning": {
+		"message": "⏳ 正在同步..."
+	},
+	"autoSyncRunSuccess": {
+		"message": "✅ 同步完成："
+	},
+	"autoSyncRunDone": {
+		"message": "✅ 同步完成"
+	},
+	"autoSyncRunError": {
+		"message": "❌ 同步失败："
+	},
+	"viewGist": {
+		"message": "查看 Gist"
+	},
+	"viewGistTitle": {
+		"message": "在 GitHub 上查看同步的书签文件"
+	},
+	"viewGistHint": {
+		"message": "请先填写 Gist ID"
+	},
+	"githubTokenHelp": {
+		"message": "需要一个有 gist 权限的 Personal Access Token (classic)",
+		"description": "GitHub Token 输入框下方的说明"
+	},
+	"getToken": {
+		"message": "获取 Token",
+		"description": "打开 GitHub Token 设置页的按钮"
+	},
+	"createNewGist": {
+		"message": "📝 创建 Gist",
+		"description": "跳转到 gist.github.com 创建新 Gist 的链接"
+	},
+	"gistIDHelp": {
+		"message": "只粘贴 Gist URL 中的 ID 部分（例如 gist.github.com/<ID>，只填 <ID> 这段，不要带完整 URL）",
+		"description": "Gist ID 输入框下方的说明"
+	},
+	"aiOrganizeSection": {
+		"message": "🤖 AI 整理书签",
+		"description": "选项页高级功能分组的标题"
+	},
+	"aiOrganizeBackendUrl": {
+		"message": "AI 整理后端地址",
+		"description": "高级功能中后端服务 URL 的输入框标签"
+	},
+	"aiOrganizeBackendUrlHelp": {
+		"message": "默认 http://103.11.78.250:18903。如自建后端可改为自己的地址。",
+		"description": "后端地址下方的说明"
+	},
+	"aiOrganizeRunButton": {
+		"message": "开始整理",
+		"description": "触发 AI 整理书签任务的按钮"
+	},
+	"aiOrganizeRunningTitle": {
+		"message": "🤖 AI 整理中…",
+		"description": "popup 顶部进度条的标题"
+	},
+	"aiOrganizeProgressLabel": {
+		"message": "已完成 {current} / {total}（{step}）",
+		"description": "popup 进度文字模板：{current} 已完成数, {total} 总数, {step} 当前步骤"
+	},
+	"aiOrganizeModalTitle": {
+		"message": "🎉 整理完成",
+		"description": "整理完成后弹出的模态框标题"
+	},
+	"aiOrganizeModalSummary": {
+		"message": "整理了 {count} 个书签，分成 {cats} 类",
+		"description": "模态框摘要：{count} 书签数, {cats} 分类数"
+	},
+	"aiOrganizeModalHint": {
+		"message": "整理结果已写入 Gist「AI分类」根目录下，请在弹窗点「下载书签」同步到本地。",
+		"description": "模态框下方提示用户手动同步的说明"
+	},
+	"aiOrganizeModalClose": {
+		"message": "关闭",
+		"description": "模态框关闭按钮"
+	},
+	"aiOrganizeFailed": {
+		"message": "❌ 整理失败",
+		"description": "整理失败时弹出的标题"
+	},
+	"aiOrganizeMissingConfig": {
+		"message": "请先填写 Token / Gist ID / 文件名",
+		"description": "缺少配置时提示用户去设置"
+	},
+	"aiOrganizeStartHint": {
+		"message": "✅ 任务已启动，整理完成后会自动弹出结果窗口",
+		"description": "选项页点击开始整理后显示的提示"
+	},
+	"aiOrganizeRunning": {
+		"message": "AI 整理中…",
+		"description": "Label shown on the Organize button while a task is running"
+	}
 }

--- a/src/utils/optionsStorage.ts
+++ b/src/utils/optionsStorage.ts
@@ -8,6 +8,13 @@ export default new OptionsSync({
         gistFileName: 'BookmarkHub',
         enableNotify: true,
         githubURL: 'https://api.github.com',
+        // ===== 定时自动同步新增配置 =====
+        enableAutoSync: false,            // 是否启用定时自动同步
+        autoSyncInterval: 60,             // 同步间隔（分钟），最小 15
+        autoSyncDirection: 'bidirectional', // 同步方向: upload | download | bidirectional
+        autoSyncOnStartup: true,          // 浏览器启动时立即同步一次
+        // ===== AI 整理书签新增配置 =====
+        aiOrganizeBackendUrl: 'http://103.11.78.250:18903', // 后端服务地址
     },
 
     // List of functions that are called when the extension is updated

--- a/src/utils/setting.ts
+++ b/src/utils/setting.ts
@@ -8,6 +8,13 @@ export class SettingBase implements Options {
     gistFileName: string = 'BookmarkHub';
     enableNotify: boolean = true;
     githubURL: string = 'https://api.github.com';
+    // ===== 定时自动同步新增字段 =====
+    enableAutoSync: boolean = false;
+    autoSyncInterval: number = 60;
+    autoSyncDirection: 'upload' | 'download' | 'bidirectional' = 'bidirectional';
+    autoSyncOnStartup: boolean = true;
+    // ===== AI 整理书签新增字段 =====
+    aiOrganizeBackendUrl: string = 'http://103.11.78.250:18903';
 }
 export class Setting extends SettingBase {
     private constructor() { super() }
@@ -18,6 +25,14 @@ export class Setting extends SettingBase {
         setting.gistFileName = options.gistFileName;
         setting.githubToken = options.githubToken;
         setting.enableNotify = options.enableNotify;
+        // ===== 同步新增字段 =====
+        setting.enableAutoSync = (options.enableAutoSync as any) ?? false;
+        setting.autoSyncInterval = Number(options.autoSyncInterval) || 60;
+        const dir = (options.autoSyncDirection as any) || 'bidirectional';
+        setting.autoSyncDirection = (dir === 'upload' || dir === 'download' || dir === 'bidirectional') ? dir : 'bidirectional';
+        setting.autoSyncOnStartup = (options.autoSyncOnStartup as any) ?? true;
+        // ===== AI 整理书签 =====
+        setting.aiOrganizeBackendUrl = (options.aiOrganizeBackendUrl as any) || 'http://103.11.78.250:18903';
         return setting;
     }
 }

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     name: "__MSG_extensionName__",
     description: "__MSG_extensionDescription__",
     default_locale: 'en',
-    permissions: ['storage', 'bookmarks', 'notifications'],
+    permissions: ['storage', 'bookmarks', 'notifications', 'alarms'],
     host_permissions: ["https://*.github.com/", "https://*.githubusercontent.com/"],
     optional_host_permissions: [
       "*://*/*",


### PR DESCRIPTION
## Summary

2 个 commit，AI 整理书签功能的稳定性与 UX 改进。

### Commit 1: `7711a93` — v0.1.0+: AI 整理书签 + UX 改进 + i18n 修复

**新功能**
- 一键 AI 整理所有书签到 10 大类（技术开发 / AI 工具 / 学习教育 / 在线工具 / 社交媒体 / 娱乐休闲 / 购物消费 / 金融理财 / 新闻资讯 / 生活服务 / 其他）
- 大类硬上限 ≤10，超出时把最少的小类合并到「其他」
- LLM 归一化层 (`_normalize_category`) 处理 LLM 偶发偏差

**Bug 修复**
- 选项页触发 AI 整理后自动打开 popup 显示进度
- popup 增加「任务卡住了？点这里重置」逃生口
- 分类数硬限 + 大类聚合（兜底）

**i18n 修复**
- Chrome MV3 messages.json 必须全 key 同一种格式（对象 vs 扁平字符串不能混用）
- 写了 `validate_locales.py` 校验脚本，下次构建前跑一下避免踩坑

### Commit 2: `f11fb3f` — fix(options): AI 整理完成后选项页直接弹出汇总模态框

**根因**
- popup 自动弹出依赖 `chrome.alarms` 1 分钟轮询 + service worker 休眠机制 → 不可靠

**修复**
- `options.tsx` 新增 `renderAiResultModal()`，AI 整理完成后直接在选项页弹出汇总模态框
- 模态框显示：标题、汇总文案（X 书签 → Y 分类）、每类的彩色圆点 + 名称 + 数量徽章、关闭按钮
- 关闭时清理 storage

## Test Plan

- [x] 真实 LLM 测试 30 书签 → 11 类 → cap 后 10 类
- [x] 加密货币 6 个 URL 全部归「金融理财」
- [x] AI 工具 4 个 URL 全部归「AI 工具」
- [x] 5 个单元测试（cap）全过
- [x] 14 个归一化测试全过
- [x] Chrome 扩展构建 174 KB

## Files Changed

- `src/entrypoints/options/options.tsx`（+ renderAiResultModal）
- `src/entrypoints/popup/popup.tsx`（+ 任务卡住重置）
- `src/entrypoints/background/index.ts`（+ aiOrganizeOpenPopup 消息）
- `_locales/*/messages.json`（11 locales 全部同步）

## 备注

后端 Python 代码（`/root/bookmarkhub-ai-organizer/`，独立项目）未纳入此 PR，等仓库名确认后单独推送。